### PR TITLE
Add support of GitHub Apps authentication

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,25 @@ spec:
             secretKeyRef:
               name: controller-manager
               key: github_token
+              optional: true
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: controller-manager
+              key: github_app_id
+              optional: true
+        - name: GITHUB_APP_INSTALLATION_ID
+          valueFrom:
+            secretKeyRef:
+              name: controller-manager
+              key: github_app_installation_id
+              optional: true
+        - name: GITHUB_APP_PRIVATE_KEY
+          value: /etc/actions-runner-controller/github_app_private_key
+        volumeMounts:
+        - name: controller-manager
+          mountPath: "/etc/actions-runner-controller"
+          readOnly: true
         resources:
           limits:
             cpu: 100m
@@ -42,4 +61,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      volumes:
+      - name: controller-manager
+        secret:
+          secretName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/main.go
+++ b/main.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
+	"strconv"
 
+	"github.com/bradleyfalzon/ghinstallation"
 	"github.com/google/go-github/v29/github"
 	actionsv1alpha1 "github.com/summerwind/actions-runner-controller/api/v1alpha1"
 	"github.com/summerwind/actions-runner-controller/controllers"
@@ -58,7 +61,13 @@ func main() {
 
 		runnerImage string
 		dockerImage string
-		ghToken     string
+
+		ghToken             string
+		ghAppID             int64
+		ghAppInstallationID int64
+		ghAppPrivateKey     string
+
+		ghClient *github.Client
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -66,21 +75,57 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&runnerImage, "runner-image", defaultRunnerImage, "The image name of self-hosted runner container.")
 	flag.StringVar(&dockerImage, "docker-image", defaultDockerImage, "The image name of docker sidecar container.")
-	flag.StringVar(&ghToken, "github-token", "", "The access token of GitHub.")
+	flag.StringVar(&ghToken, "github-token", "", "The personal access token of GitHub.")
+	flag.Int64Var(&ghAppID, "github-app-id", 0, "The application ID of GitHub App.")
+	flag.Int64Var(&ghAppInstallationID, "github-app-installation-id", 0, "The installation ID of GitHub App.")
+	flag.StringVar(&ghAppPrivateKey, "github-app-private-key", "", "The path of a private key file to authenticate as a GitHub App")
 	flag.Parse()
 
 	if ghToken == "" {
 		ghToken = os.Getenv("GITHUB_TOKEN")
 	}
-	if ghToken == "" {
-		fmt.Fprintln(os.Stderr, "Error: GitHub access token must be specified.")
-		os.Exit(1)
+	if ghAppID == 0 {
+		appID, err := strconv.ParseInt(os.Getenv("GITHUB_APP_ID"), 10, 64)
+		if err == nil {
+			ghAppID = appID
+		}
+	}
+	if ghAppInstallationID == 0 {
+		appInstallationID, err := strconv.ParseInt(os.Getenv("GITHUB_APP_INSTALLATION_ID"), 10, 64)
+		if err == nil {
+			ghAppInstallationID = appInstallationID
+		}
+	}
+	if ghAppPrivateKey == "" {
+		ghAppPrivateKey = os.Getenv("GITHUB_APP_PRIVATE_KEY")
 	}
 
-	tc := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: ghToken},
-	))
-	ghClient := github.NewClient(tc)
+	if ghAppID != 0 {
+		if ghAppInstallationID == 0 {
+			fmt.Fprintln(os.Stderr, "Error: The installation ID must be specified.")
+			os.Exit(1)
+		}
+
+		if ghAppPrivateKey == "" {
+			fmt.Fprintln(os.Stderr, "Error: The path of a private key file must be specified.")
+			os.Exit(1)
+		}
+
+		tr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, ghAppID, ghAppInstallationID, ghAppPrivateKey)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Invalid GitHub App credentials: %v\n", err)
+			os.Exit(1)
+		}
+		ghClient = github.NewClient(&http.Client{Transport: tr})
+	} else if ghToken != "" {
+		tc := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: ghToken},
+		))
+		ghClient = github.NewClient(tc)
+	} else {
+		fmt.Fprintln(os.Stderr, "Error: GitHub App credentials or personal access token must be specified.")
+		os.Exit(1)
+	}
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
 		o.Development = true


### PR DESCRIPTION
This PR adds the support of GitHub Apps authentication. This change allows us to issue a Registration Token without using a Personal Access Token.

To authenticate using GitHub Apps, you first need to create an app on GitHub:

1. Go to https://github.com/settings/apps/new and create an App (**Administration** / **Repository permissions** must be "**Read & write**").
2. Get the **App ID** displayed on the page of the created app.
3. Press **Generate a private key** at the bottom of the page of the created app to download the Private key file.
4. Click the **Install** button on the **Install App** tab of the created app to install the app in your repository.
5. Get the Installation ID from the end of the URL of the page after installation (`https://github.com/settings/installations/$ {INSTALLATION_ID}`).

You are now ready to use the app. Next, create a secret for actions-runner-controller using the information obtained as follows.

```
$ kubectl create secret generic controller-manager \
    -n actions-runner-system \
    --from-literal=github_app_id=${YOUR_APP_ID} \
    --from-literal=github_app_installation_id=${YOUR_INSTALLATION_ID} \
    --from-file=github_app_private_key=${YOUR_APP_PRIVATE_KEY_FILE_PATH}
```

The above steps will be added to the document in another PR ;-)