### PR TITLE
Update runner to v2.169.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	defaultRunnerImage = "summerwind/actions-runner:v2.168.0"
-	defaultDockerImage = "docker:19.03.8-dind"
+	defaultRunnerImage = "summerwind/actions-runner:latest"
+	defaultDockerImage = "docker:dind"
 )
 
 var (

--- a/runner/Makefile
+++ b/runner/Makefile
@@ -1,6 +1,6 @@
 NAME ?= summerwind/actions-runner
 
-RUNNER_VERSION ?= 2.168.0
+RUNNER_VERSION ?= 2.169.1
 DOCKER_VERSION ?= 19.03.8
 
 docker-build:


### PR DESCRIPTION
This PR updates runner container image to v2.169.1. This also changes the tag of the container image that the controller executes so that it always uses the latest.