### PR TITLE
Add dependencies from GitHub virtual environment to runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,3 +264,38 @@ jobs:
 ```
 
 Note that if you specify `self-hosted` in your worlflow, then this will run your job on _any_ self-hosted runner, regardless of the labels that they have.
+
+## Softeware installed in the runner image
+
+The GitHub hosted runners include a large amount of pre-installed software packages. For Ubuntu 18.04, this list can be found at https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
+
+The container image is based on Ubuntu 18.04, but it does not contain all of the software installed on the GitHub runners. It contains the following subset of packages from the GitHub runners:
+
+* Basic CLI packages
+* git (2.26)
+* docker
+* build-essentials
+
+The virtual environments from GitHub contain a lot more software packages (different versions of Java, Node.js, Golang, .NET, etc) which are not provided in the runner image. Most of these have dedicated setup actions which allow the tools to be installed on-demand in a workflow, for example: `actions/setup-java` or `actions/setup-node` 
+
+If there is a need to include packages in the runner image for which there is no setup action, then this can be achieved by building a custom container image for the runner. The easiest way is to start with the `summerwind/actions-runner` image and installing the extra dependencies directly in the docker image:
+
+```yaml
+FROM summerwind/actions-runner:v2.169.1
+
+RUN sudo apt update -y \
+  && apt install YOUR_PACKAGE
+  && rm -rf /var/lib/apt/lists/*
+```
+
+You can then configure the runner to use a custom docker image by configuring the `image` field of a `Runner` or `RunnerDeployment`:
+
+```yaml
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: Runner
+metadata:
+  name: custom-runner
+spec:
+  repository: summerwind/actions-runner-controller
+  image: YOUR_CUSTOM_DOCKER_IMAGE
+```

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,9 +3,40 @@ FROM ubuntu:18.04
 ARG RUNNER_VERSION
 ARG DOCKER_VERSION
 
-RUN apt update \
-  && apt install sudo curl ca-certificates -y --no-install-recommends \
-  && curl -L -o docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update -y \
+  && apt install -y software-properties-common \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt update -y \
+  && apt install -y --no-install-recommends \
+     build-essential \
+     curl \
+     ca-certificates \
+     dnsutils \
+     ftp \
+     git \
+     iproute2 \
+     iputils-ping \
+     jq \
+     libunwind8 \
+     locales \
+     netcat \
+     openssh-client \
+     parallel \
+     rsync \
+     shellcheck \
+     sudo \
+     telnet \
+     time \
+     tzdata \
+     unzip \
+     upx \
+     wget \
+     zip \
+     zstd \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L -o docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
   && tar zxvf docker.tgz \
   && install -o root -g root -m 755 docker/docker /usr/local/bin/docker \
   && rm -rf docker docker.tgz \
@@ -20,7 +51,8 @@ RUN mkdir -p /runner \
   && curl -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
   && tar xzf ./runner.tar.gz \
   && rm runner.tar.gz \
-  && ./bin/installdependencies.sh
+  && ./bin/installdependencies.sh \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /runner
 


### PR DESCRIPTION
Closes #51 

This adds a subset of the packages from the official Ubuntu 18.04 virtual environment to the runner image:

- Basic CLI
- Git (2.26.2)
- build-essential
- Docker

for the complete list, see: https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md