### PR TITLE
Update runner to v2.262.0

### DIFF
--- a/runner/Makefile
+++ b/runner/Makefile
@@ -1,6 +1,6 @@
 NAME ?= summerwind/actions-runner
 
-RUNNER_VERSION ?= 2.169.1
+RUNNER_VERSION ?= 2.262.0
 DOCKER_VERSION ?= 19.03.8
 
 docker-build:


### PR DESCRIPTION
This PR updates runner's version to v2.262.0.
See: https://github.com/actions/runner/releases/tag/v2.262.0