### PR TITLE
Update runner to v2.267.1

### DIFF
--- a/runner/Makefile
+++ b/runner/Makefile
@@ -1,6 +1,6 @@
 NAME ?= summerwind/actions-runner
 
-RUNNER_VERSION ?= 2.267.0
+RUNNER_VERSION ?= 2.267.1
 DOCKER_VERSION ?= 19.03.8
 
 docker-build:


### PR DESCRIPTION
This PR updates runner's version to v2.267.1.
https://github.com/actions/runner/releases/tag/v2.267.1