### PR TITLE
Add scaling-down scenario to integration test

### DIFF
--- a/github/fake/fake.go
+++ b/github/fake/fake.go
@@ -21,111 +21,116 @@ const (
 `
 )
 
-type handler struct {
+type Handler struct {
 	Status int
 	Body   string
 }
 
-func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(h.Status)
 	fmt.Fprintf(w, h.Body)
 }
 
+type ServerConfig struct {
+	*FixedResponses
+}
+
 // NewServer creates a fake server for running unit tests
 func NewServer(opts ...Option) *httptest.Server {
-	var responses FixedResponses
-
-	for _, o := range opts {
-		o(&responses)
+	config := ServerConfig{
+		FixedResponses: &FixedResponses{},
 	}
 
-	routes := map[string]handler{
+	for _, o := range opts {
+		o(&config)
+	}
+
+	routes := map[string]*Handler{
 		// For CreateRegistrationToken
-		"/repos/test/valid/actions/runners/registration-token": handler{
+		"/repos/test/valid/actions/runners/registration-token": &Handler{
 			Status: http.StatusCreated,
 			Body:   fmt.Sprintf("{\"token\": \"%s\", \"expires_at\": \"%s\"}", RegistrationToken, time.Now().Add(time.Hour*1).Format(time.RFC3339)),
 		},
-		"/repos/test/invalid/actions/runners/registration-token": handler{
+		"/repos/test/invalid/actions/runners/registration-token": &Handler{
 			Status: http.StatusOK,
 			Body:   fmt.Sprintf("{\"token\": \"%s\", \"expires_at\": \"%s\"}", RegistrationToken, time.Now().Add(time.Hour*1).Format(time.RFC3339)),
 		},
-		"/repos/test/error/actions/runners/registration-token": handler{
+		"/repos/test/error/actions/runners/registration-token": &Handler{
 			Status: http.StatusBadRequest,
 			Body:   "",
 		},
-		"/orgs/test/actions/runners/registration-token": handler{
+		"/orgs/test/actions/runners/registration-token": &Handler{
 			Status: http.StatusCreated,
 			Body:   fmt.Sprintf("{\"token\": \"%s\", \"expires_at\": \"%s\"}", RegistrationToken, time.Now().Add(time.Hour*1).Format(time.RFC3339)),
 		},
-		"/orgs/invalid/actions/runners/registration-token": handler{
+		"/orgs/invalid/actions/runners/registration-token": &Handler{
 			Status: http.StatusOK,
 			Body:   fmt.Sprintf("{\"token\": \"%s\", \"expires_at\": \"%s\"}", RegistrationToken, time.Now().Add(time.Hour*1).Format(time.RFC3339)),
 		},
-		"/orgs/error/actions/runners/registration-token": handler{
+		"/orgs/error/actions/runners/registration-token": &Handler{
 			Status: http.StatusBadRequest,
 			Body:   "",
 		},
 
 		// For ListRunners
-		"/repos/test/valid/actions/runners": handler{
+		"/repos/test/valid/actions/runners": &Handler{
 			Status: http.StatusOK,
 			Body:   RunnersListBody,
 		},
-		"/repos/test/invalid/actions/runners": handler{
+		"/repos/test/invalid/actions/runners": &Handler{
 			Status: http.StatusNoContent,
 			Body:   "",
 		},
-		"/repos/test/error/actions/runners": handler{
+		"/repos/test/error/actions/runners": &Handler{
 			Status: http.StatusBadRequest,
 			Body:   "",
 		},
-		"/orgs/test/actions/runners": handler{
+		"/orgs/test/actions/runners": &Handler{
 			Status: http.StatusOK,
 			Body:   RunnersListBody,
 		},
-		"/orgs/invalid/actions/runners": handler{
+		"/orgs/invalid/actions/runners": &Handler{
 			Status: http.StatusNoContent,
 			Body:   "",
 		},
-		"/orgs/error/actions/runners": handler{
+		"/orgs/error/actions/runners": &Handler{
 			Status: http.StatusBadRequest,
 			Body:   "",
 		},
 
 		// For RemoveRunner
-		"/repos/test/valid/actions/runners/1": handler{
+		"/repos/test/valid/actions/runners/1": &Handler{
 			Status: http.StatusNoContent,
 			Body:   "",
 		},
-		"/repos/test/invalid/actions/runners/1": handler{
+		"/repos/test/invalid/actions/runners/1": &Handler{
 			Status: http.StatusOK,
 			Body:   "",
 		},
-		"/repos/test/error/actions/runners/1": handler{
+		"/repos/test/error/actions/runners/1": &Handler{
 			Status: http.StatusBadRequest,
 			Body:   "",
 		},
-		"/orgs/test/actions/runners/1": handler{
+		"/orgs/test/actions/runners/1": &Handler{
 			Status: http.StatusNoContent,
 			Body:   "",
 		},
-		"/orgs/invalid/actions/runners/1": handler{
+		"/orgs/invalid/actions/runners/1": &Handler{
 			Status: http.StatusOK,
 			Body:   "",
 		},
-		"/orgs/error/actions/runners/1": handler{
+		"/orgs/error/actions/runners/1": &Handler{
 			Status: http.StatusBadRequest,
 			Body:   "",
 		},
 
 		// For auto-scaling based on the number of queued(pending) workflow runs
-		"/repos/test/valid/actions/runs": responses.listRepositoryWorkflowRuns.handler(),
+		"/repos/test/valid/actions/runs": config.FixedResponses.ListRepositoryWorkflowRuns,
 	}
 
 	mux := http.NewServeMux()
 	for path, handler := range routes {
-		h := handler
-		mux.Handle(path, &h)
+		mux.Handle(path, handler)
 	}
 
 	return httptest.NewServer(mux)

--- a/github/fake/options.go
+++ b/github/fake/options.go
@@ -1,28 +1,22 @@
 package fake
 
 type FixedResponses struct {
-	listRepositoryWorkflowRuns FixedResponse
+	ListRepositoryWorkflowRuns *Handler
 }
 
-type FixedResponse struct {
-	Status int
-	Body   string
-}
-
-func (r FixedResponse) handler() handler {
-	return handler{
-		Status: r.Status,
-		Body:   r.Body,
-	}
-}
-
-type Option func(responses *FixedResponses)
+type Option func(*ServerConfig)
 
 func WithListRepositoryWorkflowRunsResponse(status int, body string) Option {
-	return func(r *FixedResponses) {
-		r.listRepositoryWorkflowRuns = FixedResponse{
+	return func(c *ServerConfig) {
+		c.FixedResponses.ListRepositoryWorkflowRuns = &Handler{
 			Status: status,
 			Body:   body,
 		}
+	}
+}
+
+func WithFixedResponses(responses *FixedResponses) Option {
+	return func(c *ServerConfig) {
+		c.FixedResponses = responses
 	}
 }


### PR DESCRIPTION
This enhances the integration test suite added in #76 to cover scaling down.
In the process, I've refactored verbose/fundamentally redundant code around customizing the fake GitHub API server, and enhanced it to allow mutation on the List Workflows API mock for testing.

I've manually verified that the integration test is passing on my machine.