### PR TITLE
Allowing Finalizers for Setting Owner References

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - actions.summerwind.dev
   resources:
   - horizontalrunnerautoscalers
+  - horizontalrunnerautoscalers/finalizers
   verbs:
   - create
   - delete
@@ -30,6 +31,7 @@ rules:
   - actions.summerwind.dev
   resources:
   - runnerdeployments
+  - runnerdeployments/finalizers
   verbs:
   - create
   - delete
@@ -50,6 +52,7 @@ rules:
   - actions.summerwind.dev
   resources:
   - runnerreplicasets
+  - runnerreplicasets/finalizers
   verbs:
   - create
   - delete
@@ -70,6 +73,7 @@ rules:
   - actions.summerwind.dev
   resources:
   - runners
+  - runners/finalizers
   verbs:
   - create
   - delete
@@ -97,6 +101,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
When I deployed on OpenShift 4.5, this was one of the main issues I encountered. Once I made a `Runner` or a `RunnerDeployment`, the child resources (`Pod` and `RunnerReplicaSet` respectively) could not be made due to a lack of permission to set finalizers on the child resources.

The controller was outputting a log like this as a result:
```
2020-09-14T13:12:37.705Z        ERROR   controller-runtime.controller   Reconciler error        {"controlle
r": "runner", "request": "actions-runner-system/atlas-github-actions-runner-9mdwm-2hbng", "error": "pods \"
atlas-github-actions-runner-9mdwm-2hbng\" is forbidden: cannot set blockOwnerDeletion if an ownerReference
refers to a resource you can't set finalizers on: , <nil>"}
github.com/go-logr/zapr.(*zapLogger).Error
```

I'm not sure if _all_ of these finalizers are needed but I think they are. We can always double check with https://github.com/liggitt/audit2rbac if you'd like.