### PR TITLE
dockerEnabled for Stricter Clusters like OpenShift

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -77,6 +77,9 @@ type RunnerSpec struct {
 	EphemeralContainers []corev1.EphemeralContainer `json:"ephemeralContainers,omitempty"`
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
+	// +optional
+	DockerEnabled *bool `json:"dockerEnabled,omitempty"`
 }
 
 // ValidateRepository validates repository field.


### PR DESCRIPTION
Opening a draft while I test this out.

## Motivation

I would like it so my users can make `Runners` without Docker access since on OpenShift that requires a `SecurityContextConstraints`. Other K8s clusters might require a `PodSecurityPolicy` instead FWIW.

## Desired Experience

If users attempt to make a `Runner` with `dockerEnabled: true` and they don't have an SCC for the `ServiceAccount` they specified using `serviceAccountName` it will fail to create a pod and this is reflected in the Runner's status (this already occurs today without the `dockerEnabled` option).

If `dockerEnabled: false` is set, the user will then be able to have `Runners` create `Pods` without having to make an SCC/PSP because the Docker sidecar and volumes are omitted.