### PR TITLE
Update runner to v2.273.4

### DIFF
--- a/runner/Makefile
+++ b/runner/Makefile
@@ -1,6 +1,6 @@
 NAME ?= summerwind/actions-runner
 
-RUNNER_VERSION ?= 2.273.1
+RUNNER_VERSION ?= 2.273.4
 DOCKER_VERSION ?= 19.03.12
 
 docker-build:


### PR DESCRIPTION
This PR updates runner's version to v2.273.4.
https://github.com/actions/runner/releases/tag/v2.273.4