### PR TITLE
Update build-runner workflow to be compatible with forks, fix image push

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -32,12 +32,6 @@ jobs:
         with:
           buildx-version: latest
 
-      - name: Login to GitHub Docker Registry
-        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
       - name: Build Container Image
         working-directory: runner
         if: ${{ github.event_name == 'pull_request' }}
@@ -49,6 +43,13 @@ jobs:
             --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
             --tag ${DOCKERHUB_USERNAME}/actions-runner:latest \
             -f Dockerfile .
+
+      - name: Login to GitHub Docker Registry
+        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+        if: ${{ github.event_name == 'push' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Build and Push Container Image
         working-directory: runner

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -38,6 +38,18 @@ jobs:
           DOCKERHUB_USERNAME: ${{ github.repository_owner }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
+      - name: Build Container Image
+        working-directory: runner
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          docker buildx build \
+            --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
+            --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
+            --platform linux/amd64,linux/arm64 \
+            --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
+            --tag ${DOCKERHUB_USERNAME}/actions-runner:latest \
+            -f Dockerfile .
+
       - name: Build and Push Container Image
         working-directory: runner
         if: ${{ github.event_name == 'push' }}
@@ -49,14 +61,3 @@ jobs:
             --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
             --tag ${DOCKERHUB_USERNAME}/actions-runner:latest \
             -f Dockerfile . --push
-
-      - name: Build Container Image
-        working-directory: runner
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          docker buildx build \
-            --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
-            --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
-            --platform linux/amd64,linux/arm64 \
-            --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
-            -f Dockerfile .

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       RUNNER_VERSION: 2.273.5
       DOCKER_VERSION: 19.03.12
+      DOCKERHUB_USERNAME: ${{ github.repository_owner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,14 +39,14 @@ jobs:
             --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
             --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
             --platform linux/amd64,linux/arm64 \
-            --tag summerwind/actions-runner:v${RUNNER_VERSION} \
+            --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
             -f Dockerfile .
 
       - name: Push Container Image
         working-directory: runner
         run: |
-          docker login -u summerwind --password-stdin <<<${{ secrets.DOCKER_ACCESS_TOKEN }}
-          docker push summerwind/actions-runner:v${RUNNER_VERSION}
-          docker tag summerwind/actions-runner:v${RUNNER_VERSION} summerwind/actions-runner:latest
-          docker push summerwind/actions-runner:latest
+          docker login -u $DOCKERHUB_USERNAME --password-stdin <<<${{ secrets.DOCKER_ACCESS_TOKEN }}
+          docker push $REPO_PREFIX/actions-runner:v${RUNNER_VERSION}
+          docker tag $REPO_PREFIX/actions-runner:v${RUNNER_VERSION} $REPO_PREFIX/actions-runner:latest
+          docker push $REPO_PREFIX/actions-runner:latest
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -47,6 +47,7 @@ jobs:
             --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
             --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
+            --tag ${DOCKERHUB_USERNAME}/actions-runner:latest \
             -f Dockerfile . --push
 
       - name: Build Container Image

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -32,8 +32,26 @@ jobs:
         with:
           buildx-version: latest
 
+      - name: Login to GitHub Docker Registry
+        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build and Push Container Image
+        working-directory: runner
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          docker buildx build \
+            --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
+            --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
+            --platform linux/amd64,linux/arm64 \
+            --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
+            -f Dockerfile . --push
+
       - name: Build Container Image
         working-directory: runner
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           docker buildx build \
             --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
@@ -41,12 +59,3 @@ jobs:
             --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/actions-runner:v${RUNNER_VERSION} \
             -f Dockerfile .
-
-      - name: Push Container Image
-        working-directory: runner
-        run: |
-          docker login -u $DOCKERHUB_USERNAME --password-stdin <<<${{ secrets.DOCKER_ACCESS_TOKEN }}
-          docker push $REPO_PREFIX/actions-runner:v${RUNNER_VERSION}
-          docker tag $REPO_PREFIX/actions-runner:v${RUNNER_VERSION} $REPO_PREFIX/actions-runner:latest
-          docker push $REPO_PREFIX/actions-runner:latest
-        if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
         env:
-          DOCKERHUB_USERNAME: summerwind
+          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Build Container Image
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            --tag summerwind/actions-runner-controller:${{ env.VERSION }} \
+            --tag ${DOCKERHUB_USERNAME}/actions-runner-controller:${{ env.VERSION }} \
             -f Dockerfile . --push


### PR DESCRIPTION
A follow-up to #115 that replaces the hardcoded `summerwind` portion of the image name with `${{ github.repository_owner }}` to enable contributors to test the image pushing behavior and fixes image building by conditionally passing `--push` to the build step based on the event that triggered the workflow.

After setting the `DOCKER_ACCESS_TOKEN` Secret on my fork of this repository, I was able to use this updated workflow to [build and push](https://github.com/urcomputeringpal/actions-runner-controller/runs/1242793758?check_suite_focus=true) a [set of images](https://hub.docker.com/r/urcomputeringpal/actions-runner/tags) and confirm their functionality. I imagine this will be useful to future contributors who wish to help with the chore of keeping up with https://github.com/actions/runner/releases. 😅 