### PR TITLE
Inject Env Vars into Runner defined Container Spec

### DIFF
--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -382,6 +382,9 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 
 	if len(runner.Spec.Containers) != 0 {
 		pod.Spec.Containers = runner.Spec.Containers
+		for i := 0; i < len(pod.Spec.Containers); i++ {
+			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, env...)
+		}
 	}
 
 	if len(runner.Spec.VolumeMounts) != 0 {

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -383,7 +383,9 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 	if len(runner.Spec.Containers) != 0 {
 		pod.Spec.Containers = runner.Spec.Containers
 		for i := 0; i < len(pod.Spec.Containers); i++ {
-			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, env...)
+			if pod.Spec.Containers[i].Name == containerName {
+				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, env...)
+			}
 		}
 	}
 


### PR DESCRIPTION
The Runner definition allows for the Containers to be completely overridden.  However, if this functionality is used, the env vars containing the github credentials are not added to the containers.  Inject the variables during the step where the Runner spec Container definition overrides the default Pod to fix this.