### PR TITLE
fixed label argument in entrypoint

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -41,7 +41,7 @@ if [ -z "${RUNNER_REPO}" ] && [ -n "${RUNNER_ORG}" ] && [ -n "${RUNNER_GROUP}" ]
 fi
 
 cd /runner
-./config.sh --unattended --replace --name "${RUNNER_NAME}" --url "${GITHUB_URL}${ATTACH}" --token "${RUNNER_TOKEN}" "${RUNNER_GROUP_ARG}" "${LABEL_ARG}"
+./config.sh --unattended --replace --name "${RUNNER_NAME}" --url "${GITHUB_URL}${ATTACH}" --token "${RUNNER_TOKEN}" "${RUNNER_GROUP_ARG}" ${LABEL_ARG}
 
 for f in runsvc.sh RunnerService.js; do
   diff {bin,patched}/${f} || :

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -41,7 +41,7 @@ if [ -z "${RUNNER_REPO}" ] && [ -n "${RUNNER_ORG}" ] && [ -n "${RUNNER_GROUP}" ]
 fi
 
 cd /runner
-./config.sh --unattended --replace --name "${RUNNER_NAME}" --url "${GITHUB_URL}${ATTACH}" --token "${RUNNER_TOKEN}" "${RUNNER_GROUP_ARG}" ${LABEL_ARG}
+./config.sh --unattended --replace --name "${RUNNER_NAME}" --url "${GITHUB_URL}${ATTACH}" --token "${RUNNER_TOKEN}" ${RUNNER_GROUP_ARG} ${LABEL_ARG}
 
 for f in runsvc.sh RunnerService.js; do
   diff {bin,patched}/${f} || :


### PR DESCRIPTION
Fixes #161 

Putting quotes around "${LABEL_ARG}" will cause it to be passed as a single argument. Removing the quotes will pass them as separate arguments again (--labels x,y,z)