### PR TITLE
Improvements in the documentation for permissions and replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ kind: RunnerDeployment
 metadata:
   name: example-runner-deployment
 spec:
-  replicas: 1
   template:
     spec:
       repository: summerwind/actions-runner-controller
@@ -235,7 +234,6 @@ spec:
     repositoryNames:
     - summerwind/actions-runner-controller
 ```
-> Note the number of replicas is mandatory in `RunnerDeployment`
 
 Please also note that the sync period is set to 10 minutes by default and it's configurable via `--sync-period` flag.
 
@@ -248,7 +246,6 @@ kind: RunnerDeployment
 metadata:
   name: example-runner-deployment
 spec:
-  replicas: 1
   template:
     spec:
       repository: summerwind/actions-runner-controller

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ $ kubectl create secret generic controller-manager \
     --from-file=github_app_private_key=${PRIVATE_KEY_FILE_PATH}
 ```
 
+The permissions required are:
+- Repository: Administration (read/write)
+- Repository: Actions (read)
+- Organization: Self-hosted runners (read/write)
+
 ### Using Personal Access Token
 
 From an account that has `admin` privileges for the repository, create a [personal access token](https://github.com/settings/tokens) with `repo` scope. This token is used to register a self-hosted runner by *actions-runner-controller*.
@@ -211,6 +216,7 @@ kind: RunnerDeployment
 metadata:
   name: example-runner-deployment
 spec:
+  replicas: 1
   template:
     spec:
       repository: summerwind/actions-runner-controller
@@ -229,6 +235,7 @@ spec:
     repositoryNames:
     - summerwind/actions-runner-controller
 ```
+> Note the number of replicas is mandatory in `RunnerDeployment`
 
 Please also note that the sync period is set to 10 minutes by default and it's configurable via `--sync-period` flag.
 
@@ -241,6 +248,7 @@ kind: RunnerDeployment
 metadata:
   name: example-runner-deployment
 spec:
+  replicas: 1
   template:
     spec:
       repository: summerwind/actions-runner-controller


### PR DESCRIPTION
@summerwind I've improved a couple of things in the documentation based on the testing I've done with the repo.

- Added the permissions explicitly just in case people don't go and create the GitHub apps with the link but they go manually.
- ~Added the `replica: <num>` to horizontal autoscaling groups as this seems to be a requirement. When I didn't put the replica it was failing to start the runners~