### PR TITLE
use tcp DOCKER_HOST instead of sharing docker.sock

### DIFF
--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -401,9 +401,9 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 					MountPath: "/runner/_work",
 				},
 			},
-			Env: []corev1.EnvVar {
+			Env: []corev1.EnvVar{
 				{
-					Name: "DOCKER_TLS_CERTDIR",
+					Name:  "DOCKER_TLS_CERTDIR",
 					Value: "",
 				},
 			},

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -381,23 +381,17 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
-			{
-				Name: "docker",
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			},
 		}
 		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 			{
 				Name:      "work",
 				MountPath: "/runner/_work",
 			},
-			{
-				Name:      "docker",
-				MountPath: "/var/run",
-			},
 		}
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "DOCKER_HOST",
+			Value: "tcp://localhost:2375",
+		})
 		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
 			Name:  "docker",
 			Image: r.DockerImage,
@@ -406,9 +400,11 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 					Name:      "work",
 					MountPath: "/runner/_work",
 				},
+			},
+			Env: []corev1.EnvVar {
 				{
-					Name:      "docker",
-					MountPath: "/var/run",
+					Name: "DOCKER_TLS_CERTDIR",
+					Value: "",
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
docker:dind container creates `/var/run/docker.sock` with root user and root group.
so, docker command in runner container needs root privileges to use docker.sock and docker action fails because lack of permission.

in this PR, use tcp connection between runner and docker container, so runner container doesn't need root privileges to run docker, and can run docker action.