### PR TITLE
Add read-only permissions to actions in application template for being able to autoscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ There are two ways for actions-runner-controller to authenticate with the GitHub
 
 You can create a GitHub App for either your account or any organization. If you want to create a GitHub App for your account, open the following link to the creation page, enter any unique name in the "GitHub App name" field, and hit the "Create GitHub App" button at the bottom of the page.
 
-- [Create GitHub Apps on your account](https://github.com/settings/apps/new?url=http://github.com/summerwind/actions-runner-controller&webhook_active=false&public=false&administration=write)
+- [Create GitHub Apps on your account](https://github.com/settings/apps/new?url=http://github.com/summerwind/actions-runner-controller&webhook_active=false&public=false&administration=write&actions=read)
 
 If you want to create a GitHub App for your organization, replace the `:org` part of the following URL with your organization name before opening it. Then enter any unique name in the "GitHub App name" field, and hit the "Create GitHub App" button at the bottom of the page to create a GitHub App.
 
-- [Create GitHub Apps on your organization](https://github.com/organizations/:org/settings/apps/new?url=http://github.com/summerwind/actions-runner-controller&webhook_active=false&public=false&administration=write&organization_self_hosted_runners=write)
+- [Create GitHub Apps on your organization](https://github.com/organizations/:org/settings/apps/new?url=http://github.com/summerwind/actions-runner-controller&webhook_active=false&public=false&administration=write&organization_self_hosted_runners=write&actions=read)
 
 You will see an *App ID* on the page of the GitHub App you created as follows, the value of this App ID will be used later.
 


### PR DESCRIPTION
Hi,

Thanks for the great work you've done with this project. It's definitely been of great help to integrate GitHub Actions with Kubernetes.

I noticed in the documentation for creating a GitHub application to authorize the controller that no `actions` scope was set. However, without `read-only` permission, I get 403 when the controller fetches pending runs to autoscale. Please let me know if I'm wrong.

This PR adds that scope to the default application template you link in the documentation.

Cheers