### PR TITLE
parametrized working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,10 @@ spec:
               value: abcd1234
           securityContext:
             runAsUser: 0
+      # if workDir is not specified, the default working directory is /runner/_work
+      # this setting allows you to customize the working directory location
+      # for example, the below setting is the same as on the ubuntu-18.04 image
+      workDir: /home/runner/work
 ```
 
 ## Runner labels

--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -59,6 +59,8 @@ type RunnerSpec struct {
 
 	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
+	// +optional
+	WorkDir string `json:"workDir,omitempty"`
 
 	// +optional
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -1533,6 +1533,8 @@ spec:
                           - name
                         type: object
                       type: array
+                    workDir:
+                      type: string
                   type: object
               type: object
           required:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -1533,6 +1533,8 @@ spec:
                           - name
                         type: object
                       type: array
+                    workDir:
+                      type: string
                   type: object
               type: object
           required:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -1526,6 +1526,8 @@ spec:
                   - name
                 type: object
               type: array
+            workDir:
+              type: string
           type: object
         status:
           description: RunnerStatus defines the observed state of Runner

--- a/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
+++ b/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: horizontalrunnerautoscalers.actions.summerwind.dev
 spec:

--- a/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
+++ b/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: horizontalrunnerautoscalers.actions.summerwind.dev
 spec:

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: runnerdeployments.actions.summerwind.dev
 spec:
@@ -407,12 +407,20 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -465,8 +473,12 @@ spec:
                                     description: 'Container name: required for volumes, optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -571,12 +583,20 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -926,8 +946,12 @@ spec:
                                           description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
                                           description: Specifies the output format of the exposed resources, defaults to "1"
-                                          type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         resource:
                                           description: 'Required: resource to select'
                                           type: string
@@ -946,8 +970,12 @@ spec:
                                 description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                 type: string
                               sizeLimit:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
                                 description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                             type: object
                           fc:
                             description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
@@ -1254,8 +1282,12 @@ spec:
                                                     description: 'Container name: required for volumes, optional for env vars'
                                                     type: string
                                                   divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
                                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                                    type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource to select'
                                                     type: string

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: runnerdeployments.actions.summerwind.dev
 spec:
@@ -407,20 +407,12 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -473,12 +465,8 @@ spec:
                                     description: 'Container name: required for volumes, optional for env vars'
                                     type: string
                                   divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
+                                    type: string
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -583,20 +571,12 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -946,12 +926,8 @@ spec:
                                           description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
                                           description: Specifies the output format of the exposed resources, defaults to "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
+                                          type: string
                                         resource:
                                           description: 'Required: resource to select'
                                           type: string
@@ -970,12 +946,8 @@ spec:
                                 description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                 type: string
                               sizeLimit:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
                                 description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
+                                type: string
                             type: object
                           fc:
                             description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
@@ -1282,12 +1254,8 @@ spec:
                                                     description: 'Container name: required for volumes, optional for env vars'
                                                     type: string
                                                   divisor:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
                                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
+                                                    type: string
                                                   resource:
                                                     description: 'Required: resource to select'
                                                     type: string
@@ -1533,6 +1501,8 @@ spec:
                           - name
                         type: object
                       type: array
+                    workDir:
+                      type: string
                   type: object
               type: object
           required:

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: runnerreplicasets.actions.summerwind.dev
 spec:
@@ -407,12 +407,20 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -465,8 +473,12 @@ spec:
                                     description: 'Container name: required for volumes, optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -571,12 +583,20 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -926,8 +946,12 @@ spec:
                                           description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
                                           description: Specifies the output format of the exposed resources, defaults to "1"
-                                          type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         resource:
                                           description: 'Required: resource to select'
                                           type: string
@@ -946,8 +970,12 @@ spec:
                                 description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                 type: string
                               sizeLimit:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
                                 description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                             type: object
                           fc:
                             description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
@@ -1254,8 +1282,12 @@ spec:
                                                     description: 'Container name: required for volumes, optional for env vars'
                                                     type: string
                                                   divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
                                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                                    type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource to select'
                                                     type: string

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: runnerreplicasets.actions.summerwind.dev
 spec:
@@ -407,20 +407,12 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -473,12 +465,8 @@ spec:
                                     description: 'Container name: required for volumes, optional for env vars'
                                     type: string
                                   divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
+                                    type: string
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -583,20 +571,12 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
@@ -946,12 +926,8 @@ spec:
                                           description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
                                           description: Specifies the output format of the exposed resources, defaults to "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
+                                          type: string
                                         resource:
                                           description: 'Required: resource to select'
                                           type: string
@@ -970,12 +946,8 @@ spec:
                                 description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                 type: string
                               sizeLimit:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
                                 description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
+                                type: string
                             type: object
                           fc:
                             description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
@@ -1282,12 +1254,8 @@ spec:
                                                     description: 'Container name: required for volumes, optional for env vars'
                                                     type: string
                                                   divisor:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
                                                     description: Specifies the output format of the exposed resources, defaults to "1"
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
+                                                    type: string
                                                   resource:
                                                     description: 'Required: resource to select'
                                                     type: string
@@ -1533,6 +1501,8 @@ spec:
                           - name
                         type: object
                       type: array
+                    workDir:
+                      type: string
                   type: object
               type: object
           required:

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: runners.actions.summerwind.dev
 spec:
@@ -400,20 +400,12 @@ spec:
               properties:
                 limits:
                   additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
+                    type: string
                   description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
                 requests:
                   additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
+                    type: string
                   description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
@@ -466,12 +458,8 @@ spec:
                             description: 'Container name: required for volumes, optional for env vars'
                             type: string
                           divisor:
-                            anyOf:
-                              - type: integer
-                              - type: string
                             description: Specifies the output format of the exposed resources, defaults to "1"
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                           resource:
                             description: 'Required: resource to select'
                             type: string
@@ -576,20 +564,12 @@ spec:
               properties:
                 limits:
                   additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
+                    type: string
                   description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
                 requests:
                   additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
+                    type: string
                   description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
@@ -939,12 +919,8 @@ spec:
                                   description: 'Container name: required for volumes, optional for env vars'
                                   type: string
                                 divisor:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
                                   description: Specifies the output format of the exposed resources, defaults to "1"
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
+                                  type: string
                                 resource:
                                   description: 'Required: resource to select'
                                   type: string
@@ -963,12 +939,8 @@ spec:
                         description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
+                        type: string
                     type: object
                   fc:
                     description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
@@ -1275,12 +1247,8 @@ spec:
                                             description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
                                             description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
+                                            type: string
                                           resource:
                                             description: 'Required: resource to select'
                                             type: string
@@ -1526,6 +1494,8 @@ spec:
                   - name
                 type: object
               type: array
+            workDir:
+              type: string
           type: object
         status:
           description: RunnerStatus defines the observed state of Runner

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: runners.actions.summerwind.dev
 spec:
@@ -400,12 +400,20 @@ spec:
               properties:
                 limits:
                   additionalProperties:
-                    type: string
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
                 requests:
                   additionalProperties:
-                    type: string
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
@@ -458,8 +466,12 @@ spec:
                             description: 'Container name: required for volumes, optional for env vars'
                             type: string
                           divisor:
+                            anyOf:
+                              - type: integer
+                              - type: string
                             description: Specifies the output format of the exposed resources, defaults to "1"
-                            type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           resource:
                             description: 'Required: resource to select'
                             type: string
@@ -564,12 +576,20 @@ spec:
               properties:
                 limits:
                   additionalProperties:
-                    type: string
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
                 requests:
                   additionalProperties:
-                    type: string
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
@@ -919,8 +939,12 @@ spec:
                                   description: 'Container name: required for volumes, optional for env vars'
                                   type: string
                                 divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
                                   description: Specifies the output format of the exposed resources, defaults to "1"
-                                  type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 resource:
                                   description: 'Required: resource to select'
                                   type: string
@@ -939,8 +963,12 @@ spec:
                         description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
+                        anyOf:
+                          - type: integer
+                          - type: string
                         description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   fc:
                     description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
@@ -1247,8 +1275,12 @@ spec:
                                             description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
                                             description: Specifies the output format of the exposed resources, defaults to "1"
-                                            type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
                                           resource:
                                             description: 'Required: resource to select'
                                             type: string

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -307,6 +307,11 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 		runnerImage = r.RunnerImage
 	}
 
+	workDir := runner.Spec.WorkDir
+	if workDir == "" {
+		workDir = "/runner/_work"
+	}
+
 	runnerImagePullPolicy := runner.Spec.ImagePullPolicy
 	if runnerImagePullPolicy == "" {
 		runnerImagePullPolicy = corev1.PullAlways
@@ -344,6 +349,10 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 		{
 			Name:  "GITHUB_URL",
 			Value: r.GitHubClient.GithubBaseURL,
+		},
+		{
+			Name:  "RUNNER_WORKDIR",
+			Value: workDir,
 		},
 	}
 
@@ -386,7 +395,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 			{
 				Name:      "work",
-				MountPath: "/runner/_work",
+				MountPath: workDir,
 			},
 		}
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
@@ -399,7 +408,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "work",
-					MountPath: "/runner/_work",
+					MountPath: workDir,
 				},
 			},
 			Env: []corev1.EnvVar{

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -27,6 +27,10 @@ else
   exit 1
 fi
 
+if [ -n "${RUNNER_WORKDIR}" ]; then
+  WORKDIR_ARG="--work ${RUNNER_WORKDIR}"
+fi
+
 if [ -n "${RUNNER_LABELS}" ]; then
   LABEL_ARG="--labels ${RUNNER_LABELS}"
 fi
@@ -41,7 +45,7 @@ if [ -z "${RUNNER_REPO}" ] && [ -n "${RUNNER_ORG}" ] && [ -n "${RUNNER_GROUP}" ]
 fi
 
 cd /runner
-./config.sh --unattended --replace --name "${RUNNER_NAME}" --url "${GITHUB_URL}${ATTACH}" --token "${RUNNER_TOKEN}" ${RUNNER_GROUP_ARG} ${LABEL_ARG}
+./config.sh --unattended --replace --name "${RUNNER_NAME}" --url "${GITHUB_URL}${ATTACH}" --token "${RUNNER_TOKEN}" ${RUNNER_GROUP_ARG} ${LABEL_ARG} ${WORKDIR_ARG}
 
 for f in runsvc.sh RunnerService.js; do
   diff {bin,patched}/${f} || :


### PR DESCRIPTION
The default working directory on the runner is `/runner/_work`, which is fine for most cases.

However, I ran into the issue when using multiple consecutive jobs where I am mixing ubuntu-latest and the summerwind runners, that restoring cache and artifacts may not always work as expected, because the working directory is different on `ubuntu-latest` (`/home/runner/work`). In this case it may be convenient to change the working directory.

In order to be compatible with older versions, I added a `workDir` parameter to the runner spec. If not specified, this will use the old `/runner/_work` directory like normal. When `workDir` is specified, the runner is configured using `--work ${RUNNER_WORKDIR}`.

### Example

I generated an image v2.274.1-wd with the updated entrypoint for testing. This supports the (optional) `workDir` parameter as in the example below.

```yaml
apiVersion: actions.summerwind.dev/v1alpha1
kind: Runner
metadata:
  name: my-runner
spec:
  image: reiniert/actions-runner-dind:v2.274.1-wd
  organization: my-org
  workDir: /home/runner/work
```

### Compatibility

Since this change involves both the controller as in the runner docker image, I have analyzed the compatibility modes between them.

Controller | Runner Image | Working
---|---|---
new | new | ✔️ 
old | new | ✔️ 
new | old | ❌/ ✔️  

So in short, the image can be updated without issues. Using the _new_ controller with an _old_ image will still work, though for the default image, the `mountPath: /your/custom/path` will be set whereas the runner would still work in the old location. Since the image is more frequently (and automatically) updated, I feel that this is not such a big problem, would you agree?

### Testing

Change was tested with both the regular as well as the DinD image. Results:

image | Spec.WorkDir | working directory reported by workflow
---|---|---
default | - | `/runner/_work`
default | `/home/runner/work` | `/home/runner/work`
DinD | - | `/runner/_work`
DinD | `/home/runner/work` | `/home/runner/work`

### Acceptance tests

I tested this with the following runners (DinD/normal with/without custom workdirs)

```yaml
# DinD runner with default working directory
apiVersion: actions.summerwind.dev/v1alpha1
kind: Runner
metadata:
  name: dind
spec:
  image: "reiniert/actions-runner-dind:v2.274.2"
  dockerdWithinRunnerContainer: true
  repository: reiniertimmer/actions-runner-controller
  labels:
    - dind
---
# DinD runner with customized working directory
apiVersion: actions.summerwind.dev/v1alpha1
kind: Runner
metadata:
  name: dind-wd
spec:
  image: "reiniert/actions-runner-dind:v2.274.2"
  dockerdWithinRunnerContainer: true
  repository: reiniertimmer/actions-runner-controller
  workDir: "/home/runner/work"
  labels:
    - dind-wd
---
# Default runner with default working directory
apiVersion: actions.summerwind.dev/v1alpha1
kind: Runner
metadata:
  name: normal
spec:
  image: "reiniert/actions-runner:v2.274.2"
  dockerdWithinRunnerContainer: false
  repository: reiniertimmer/actions-runner-controller
  labels:
    - normal
---
# Default runner with custom working directory
apiVersion: actions.summerwind.dev/v1alpha1
kind: Runner
metadata:
  name: normal-wd
spec:
  image: "reiniert/actions-runner:v2.274.2"
  dockerdWithinRunnerContainer: false
  repository: reiniertimmer/actions-runner-controller
  workDir: "/home/runner/work"
  labels:
    - normal-wd
```

Then I ran the following acceptance test workflow:

```yaml
on: push
name: Validate workdirs
jobs:
  build:
    runs-on: ${{ matrix.runs-on }}
    name: ${{ matrix.runs-on }}
    strategy:
      matrix:
        include:
          - runs-on: dind
            work-dir: /runner/_work
          - runs-on: dind-wd
            work-dir: /home/runner/work
          - runs-on: normal
            work-dir: /runner/_work
          - runs-on: normal-wd
            work-dir: /home/runner/work
    steps:
      - name: Check working directory
        run: |
          [ "$RUNNER_WORKSPACE" == "${{ matrix.work-dir }}/${{ github.event.repository.name }}" ]
```

This workflow runs a matrix test to validate the `$RUNNER_WORKSPACE` environment variable, which defaults to `/runner/_work/$REPO_NAME` but can be customized using the `workDir` parameter in the runner spec.

See the result on: https://github.com/reiniertimmer/actions-runner-controller/actions/runs/375208748/workflow