### PR TITLE
Make Runner{Deployment,ReplicaSet} replicas actually optional

### DIFF
--- a/acceptance/testdata/runnerdeploy.yaml
+++ b/acceptance/testdata/runnerdeploy.yaml
@@ -3,7 +3,7 @@ kind: RunnerDeployment
 metadata:
   name: example-runnerdeploy
 spec:
-  replicas: 1
+#  replicas: 1
   template:
     spec:
       repository: mumoshu/actions-runner-controller-ci

--- a/api/v1alpha1/runnerdeployment_types.go
+++ b/api/v1alpha1/runnerdeployment_types.go
@@ -27,6 +27,7 @@ const (
 // RunnerReplicaSetSpec defines the desired state of RunnerDeployment
 type RunnerDeploymentSpec struct {
 	// +optional
+	// +nullable
 	Replicas *int `json:"replicas,omitempty"`
 
 	Template RunnerTemplate `json:"template"`

--- a/api/v1alpha1/runnerreplicaset_types.go
+++ b/api/v1alpha1/runnerreplicaset_types.go
@@ -22,7 +22,9 @@ import (
 
 // RunnerReplicaSetSpec defines the desired state of RunnerReplicaSet
 type RunnerReplicaSetSpec struct {
-	Replicas *int `json:"replicas"`
+	// +optional
+	// +nullable
+	Replicas *int `json:"replicas,omitempty"`
 
 	Template RunnerTemplate `json:"template"`
 }

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -41,6 +41,7 @@ spec:
           description: RunnerReplicaSetSpec defines the desired state of RunnerDeployment
           properties:
             replicas:
+              nullable: true
               type: integer
             template:
               properties:

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -41,6 +41,7 @@ spec:
           description: RunnerReplicaSetSpec defines the desired state of RunnerReplicaSet
           properties:
             replicas:
+              nullable: true
               type: integer
             template:
               properties:
@@ -1533,7 +1534,6 @@ spec:
                   type: object
               type: object
           required:
-            - replicas
             - template
           type: object
         status:


### PR DESCRIPTION
If omitted, it properly defaults to 1.

Fixes #64