### PR TITLE
Updated deprecated crazy-max buildx workflows to use docker v2

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -34,45 +34,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: linux/amd64,linux/arm64
-
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
 
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
-
-      - name: Build Container Image
-        working-directory: runner
+      - name: Build and Push
+        uses: docker/build-push-action@v2
         if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          docker build \
-            --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
-            --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
-            --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION} \
-            --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest \
-            -f ${{ matrix.dockerfile }} .
+        with:
+          context: runner
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: false
+          build-args: |
+            RUNNER_VERSION=${RUNNER_VERSION}
+            DOCKER_VERSION=${DOCKER_VERSION}
+          tags: |
+            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION}
+            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest      
 
-      - name: Login to GitHub Docker Registry
-        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         if: ${{ github.event_name == 'push' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Build and Push Container Image
-        working-directory: runner
+      - name: Build and Push
+        uses: docker/build-push-action@v2
         if: ${{ github.event_name == 'push' }}
-        run: |
-          docker build \
-            --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
-            --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
-            --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION} \
-            --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest \
-            -f ${{ matrix.dockerfile }} . --push
+        with:
+          context: runner
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            RUNNER_VERSION=${RUNNER_VERSION}
+            DOCKER_VERSION=${DOCKER_VERSION}
+          tags: |
+            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION}
+            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: all
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         id: buildx
@@ -55,7 +55,6 @@ jobs:
           docker build \
             --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
             --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
-            --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION} \
             --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest \
             -f ${{ matrix.dockerfile }} .
@@ -74,7 +73,6 @@ jobs:
           docker build \
             --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
             --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
-            --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION} \
             --tag ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest \
             -f ${{ matrix.dockerfile }} . --push

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -47,6 +47,7 @@ jobs:
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Build [and Push]
+        id: buildx
         uses: docker/build-push-action@v2
         with:
           context: ./runner

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           version: latest
 
-      - name: Build and Push
+      - name: Build (no Push)
         uses: docker/build-push-action@v2
         if: ${{ github.event_name == 'pull_request' }}
         with:
@@ -48,11 +48,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           build-args: |
-            RUNNER_VERSION=${RUNNER_VERSION}
-            DOCKER_VERSION=${DOCKER_VERSION}
+            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
+            DOCKER_VERSION=${{ env.DOCKER_VERSION }}
           tags: |
-            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION}
-            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest      
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:latest      
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -70,8 +70,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            RUNNER_VERSION=${RUNNER_VERSION}
-            DOCKER_VERSION=${DOCKER_VERSION}
+            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
+            DOCKER_VERSION=${{ env.DOCKER_VERSION }}
           tags: |
-            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:v${RUNNER_VERSION}
-            ${DOCKERHUB_USERNAME}/${{ matrix.name }}:latest
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:latest

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -44,7 +44,7 @@ jobs:
         working-directory: runner
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          docker buildx build \
+          docker build \
             --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
             --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
             --platform linux/amd64,linux/arm64 \
@@ -63,7 +63,7 @@ jobs:
         working-directory: runner
         if: ${{ github.event_name == 'push' }}
         run: |
-          docker buildx build \
+          docker build \
             --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
             --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
             --platform linux/amd64,linux/arm64 \

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
@@ -47,7 +50,6 @@ jobs:
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Build [and Push]
-        id: buildx
         uses: docker/build-push-action@v2
         with:
           context: ./runner

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -39,21 +39,6 @@ jobs:
         with:
           version: latest
 
-      - name: Build (no Push)
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        working-directory: runner
-        with:
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: false
-          build-args: |
-            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
-            DOCKER_VERSION=${{ env.DOCKER_VERSION }}
-          tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:latest      
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         if: ${{ github.event_name == 'push' }}
@@ -61,14 +46,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Build and Push
+      - name: Build [and Push]
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'push' }}
-        working-directory: runner
         with:
-          file: ${{ matrix.dockerfile }}
+          context: ./runner
+          file: ./runner/${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             RUNNER_VERSION=${{ env.RUNNER_VERSION }}
             DOCKER_VERSION=${{ env.DOCKER_VERSION }}

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -34,11 +34,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Build Container Image
         working-directory: runner

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Build (no Push)
         uses: docker/build-push-action@v2
         if: ${{ github.event_name == 'pull_request' }}
+        working-directory: runner
         with:
-          context: runner
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: false
@@ -64,8 +64,8 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@v2
         if: ${{ github.event_name == 'push' }}
+        working-directory: runner
         with:
-          context: runner
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -38,7 +38,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Build Container Image
         working-directory: runner

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
           buildx-version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: all
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         id: buildx
@@ -54,6 +54,5 @@ jobs:
           DOCKERHUB_USERNAME: ${{ github.repository_owner }}
         run: |
           docker build \
-            --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/actions-runner-controller:${{ env.VERSION }} \
             -f Dockerfile . --push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
           buildx-version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,30 +29,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make github-release
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: linux/amd64,linux/arm64
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
 
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Login to GitHub Docker Registry
-        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+      - name: Build and Push
+        uses: docker/build-push-action@v2
         env:
           DOCKERHUB_USERNAME: ${{ github.repository_owner }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        with:
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${DOCKERHUB_USERNAME}/actions-runner-controller:${{ env.VERSION }} 
 
-      - name: Build Container Image
-        env:
-          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
-        run: |
-          docker build \
-            --tag ${DOCKERHUB_USERNAME}/actions-runner-controller:${{ env.VERSION }} \
-            -f Dockerfile . --push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Release
+    env:
+      DOCKERHUB_USERNAME: ${{ github.repository_owner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,11 +45,9 @@ jobs:
 
       - name: Build and Push
         uses: docker/build-push-action@v2
-        env:
-          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
         with:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${DOCKERHUB_USERNAME}/actions-runner-controller:${{ env.VERSION }} 
+          tags: ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:${{ env.VERSION }} 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ github.repository_owner }}
         run: |
-          docker buildx build \
+          docker build \
             --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/actions-runner-controller:${{ env.VERSION }} \
             -f Dockerfile . --push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make github-release
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make github-release
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
           buildx-version: latest
 

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -13,11 +13,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: release-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ github.repository_owner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,11 +29,9 @@ jobs:
 
       - name: Build and Push
         uses: docker/build-push-action@v2
-        env:
-          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
         with:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${DOCKERHUB_USERNAME}/actions-runner-controller:latest 
+          tags: ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:latest 
 

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -17,7 +17,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ github.repository_owner }}
         run: |
-          docker buildx build \
+          docker build \
             --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/actions-runner-controller:latest \
             -f Dockerfile . --push

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: all
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         id: buildx
@@ -38,6 +38,5 @@ jobs:
           DOCKERHUB_USERNAME: ${{ github.repository_owner }}
         run: |
           docker build \
-            --platform linux/amd64,linux/arm64 \
             --tag ${DOCKERHUB_USERNAME}/actions-runner-controller:latest \
             -f Dockerfile . --push

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -13,30 +13,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: linux/amd64,linux/arm64
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
 
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Login to GitHub Docker Registry
-        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+      - name: Build and Push
+        uses: docker/build-push-action@v2
         env:
           DOCKERHUB_USERNAME: ${{ github.repository_owner }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        with:
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${DOCKERHUB_USERNAME}/actions-runner-controller:latest 
 
-      - name: Build Container Image
-        env:
-          DOCKERHUB_USERNAME: ${{ github.repository_owner }}
-        run: |
-          docker build \
-            --tag ${DOCKERHUB_USERNAME}/actions-runner-controller:latest \
-            -f Dockerfile . --push

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -5,11 +5,11 @@ ARG RUNNER_VERSION=2.274.2
 ARG DOCKER_VERSION=19.03.12
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y 
-RUN apt install -y software-properties-common 
-RUN add-apt-repository -y ppa:git-core/ppa 
-RUN apt update -y 
-RUN apt install -y --no-install-recommends \
+RUN apt update -y \
+  && apt install -y software-properties-common \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt update -y \
+  && apt install -y --no-install-recommends \
   build-essential \
   curl \
   ca-certificates \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -5,11 +5,11 @@ ARG RUNNER_VERSION=2.274.2
 ARG DOCKER_VERSION=19.03.12
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y \
-  && apt install -y software-properties-common \
-  && add-apt-repository -y ppa:git-core/ppa \
-  && apt update -y \
-  && apt install -y --no-install-recommends \
+RUN apt -oDebug::pkgAcquire::Worker=1 update -y 
+RUN apt -oDebug::pkgAcquire::Worker=1 install -y software-properties-common 
+RUN add-apt-repository -y ppa:git-core/ppa 
+RUN apt -oDebug::pkgAcquire::Worker=1 update -y 
+RUN apt -oDebug::pkgAcquire::Worker=1 install -y --no-install-recommends \
   build-essential \
   curl \
   ca-certificates \
@@ -73,4 +73,3 @@ COPY patched /runner/patched
 USER runner
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["/runner/entrypoint.sh"]
-

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -5,11 +5,11 @@ ARG RUNNER_VERSION=2.274.2
 ARG DOCKER_VERSION=19.03.12
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt -oDebug::pkgAcquire::Worker=1 update -y 
-RUN apt -oDebug::pkgAcquire::Worker=1 install -y software-properties-common 
+RUN apt update -y 
+RUN apt install -y software-properties-common 
 RUN add-apt-repository -y ppa:git-core/ppa 
-RUN apt -oDebug::pkgAcquire::Worker=1 update -y 
-RUN apt -oDebug::pkgAcquire::Worker=1 install -y --no-install-recommends \
+RUN apt update -y 
+RUN apt install -y --no-install-recommends \
   build-essential \
   curl \
   ca-certificates \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -73,3 +73,4 @@ COPY patched /runner/patched
 USER runner
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["/runner/entrypoint.sh"]
+


### PR DESCRIPTION
Deprecated action: `crazy-max/setup-buildx-action@v1`
Replaced with:
  `docker/setup-qemu-action@v1`
  `docker/setup-buildx-action@v1`
  `docker/login-action@v1`
  `docker/build-push-action@v2`

See: https://github.com/crazy-max/ghaction-docker-buildx

Reworked and cleaned up the workflows. - Not been able to test push (master) as this needs doing on merge.