### PR TITLE
[BUG?]: Create mountpoint for /externals/

### DIFF
--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -382,11 +382,21 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
+			{
+				Name: "externals",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
 		}
 		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 			{
 				Name:      "work",
 				MountPath: "/runner/_work",
+			},
+			{
+				Name:      "externals",
+				MountPath: "/runner/externals",
 			},
 		}
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
@@ -400,6 +410,10 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 				{
 					Name:      "work",
 					MountPath: "/runner/_work",
+				},
+				{
+					Name:      "externals",
+					MountPath: "/runner/externals",
 				},
 			},
 			Env: []corev1.EnvVar{

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -55,7 +55,7 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
   && usermod -aG docker runner \
   && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
 
-# Runner download supports amd64 as x64
+# Runner download supports amd64 as x64. Externalstmp is needed for making mount points work inside DinD.
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
   && if [ "$ARCH" = "amd64" ]; then export ARCH=x64 ; fi \
   && mkdir -p /runner \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 ARG TARGETPLATFORM
-ARG RUNNER_VERSION=2.274.1
+ARG RUNNER_VERSION=2.274.2
 ARG DOCKER_VERSION=19.03.12
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -64,6 +64,7 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
   && tar xzf ./runner.tar.gz \
   && rm runner.tar.gz \
   && ./bin/installdependencies.sh \
+  && mv ./externals ./externalstmp \
   && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /runner

--- a/runner/Makefile
+++ b/runner/Makefile
@@ -2,7 +2,7 @@ NAME ?= summerwind/actions-runner
 DIND_RUNNER_NAME ?= ${NAME}-dind
 TAG ?= latest
 
-RUNNER_VERSION ?= 2.273.5
+RUNNER_VERSION ?= 2.274.2
 DOCKER_VERSION ?= 19.03.12
 
 # default list of platforms for which multiarch image is built

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -43,6 +43,9 @@ fi
 cd /runner
 ./config.sh --unattended --replace --name "${RUNNER_NAME}" --url "${GITHUB_URL}${ATTACH}" --token "${RUNNER_TOKEN}" ${RUNNER_GROUP_ARG} ${LABEL_ARG}
 
+# Hack due to the DinD volumes
+mv ./externalstmp/* ./externals/
+
 for f in runsvc.sh RunnerService.js; do
   diff {bin,patched}/${f} || :
   sudo mv bin/${f}{,.bak}


### PR DESCRIPTION
I am totally aware that the proposed changes in this PR can be considered _hacky_ . The goal of this PR, however, is to receive input from you, the community, on how we can solve this in a better way.

I already have an open issue, but let me try to give some more context and explain how this PR tries to solve this.
When you deploy a `RunnerDeployment` with  `dockerdWithinRunnerContainer: false` and your Github Workflow uses a container (`container: <xyz>`) set, you run into the following error:

```
/usr/local/bin/docker exec  0712ca6bb1f7951bd47b4e43a7c86611e41ea24042a80e4c01192869a6d50322 sh -c "cat /etc/*release | grep ^ID"
OCI runtime exec failed: exec failed: container_linux.go:349: starting container process caused "exec: \"/__e/node12/bin/node\": stat /__e/node12/bin/node: no such file or directory": unknown
```
This error appears at first at the `actions/checkout@v2` action of your Workflow. Downgrading the action to `v1` will solve this error since `v1` uses Bash to perform the checkout. However, in cases where your Workflow also uses the `action/cache` action, you will receive the same error; this is due to the fact that both versions of `cache` depend on NodeJS.

Your actual Workflow/Build container essentially runs inside the sidecarContainer of your runner. This can be confirmed when you actually check dockerd of your worker node. The error indicates that it is missing the `node` binary. Checking the Workflow/Build container creation, you will see something like this:

```
  /usr/bin/docker create --name 3485f544d725497da2bb0fac8e8a3a6e_<image_name>_562d9e --label 60e226 --workdir /__w/<name> --network github_network_c96f95cd7a224ebd838159386d6c81ca  -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/runner/_work":"/__w" -v "/runner/externals":"/__e":ro -v "/runner/_work/_temp":"/__w/_temp" -v "/runner/_work/_actions":"/__w/_actions" -v "/runner/_work/_tool":"/__w/_tool" -v "/runner/_work/_temp/_github_home":"/github/home" -v "/runner/_work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" ***/<image_name> "-f" "/dev/null"
```

The important bit here is the `/runner/externals":"/__e` mount point, which is not working. I confirmed this by checking (docker exec) the actual Workflow/Build container and the `/__e` directory turned out empty. This is exactly what the error message indicates.
This actually makes sense, because we have docker-in-docker situation; A DinD container uses the parent's HOST dockerd. So the volumes that are referenced are not from the sidecarContainer, but from the actual host, meaning an empty directory is created.
I obviously tried using `volumes` & `volumeMounts` inside my manifest, but that will result in the actions-runner-controller not passing any environment variables to my Pod anymore (e.g. the GHA Token).
