### PR TITLE
runner: Add support for ruby/setup-ruby

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,12 @@ release: manifests
 	mkdir -p release
 	kustomize build config/default > release/actions-runner-controller.yaml
 
+.PHONY: release/clean
+release/clean:
+	rm -rf release
+
 .PHONY: acceptance
-acceptance: release
+acceptance: release/clean release
 	ACCEPTANCE_TEST_SECRET_TYPE=token make acceptance/setup acceptance/tests acceptance/teardown
 	ACCEPTANCE_TEST_SECRET_TYPE=app make acceptance/setup acceptance/tests acceptance/teardown
 	ACCEPTANCE_TEST_DEPLOYMENT_TOOL=helm ACCEPTANCE_TEST_SECRET_TYPE=token make acceptance/setup acceptance/tests acceptance/teardown

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -56,6 +56,10 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
   && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
 
 # Runner download supports amd64 as x64. Externalstmp is needed for making mount points work inside DinD.
+#
+# libyaml-dev is required for ruby/setup-ruby action.
+# It is installed after installdependencies.sh and before removing /var/lib/apt/lists
+# to avoid rerunning apt-update on its own.
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
   && if [ "$ARCH" = "amd64" ]; then export ARCH=x64 ; fi \
   && mkdir -p /runner \
@@ -65,7 +69,13 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
   && rm runner.tar.gz \
   && ./bin/installdependencies.sh \
   && mv ./externals ./externalstmp \
+  && apt-get install -y libyaml-dev \
   && rm -rf /var/lib/apt/lists/*
+
+RUN echo AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache > /runner.env \
+  && mkdir /opt/hostedtoolcache \
+  && chgrp runner /opt/hostedtoolcache \
+  && chmod g+rwx /opt/hostedtoolcache
 
 COPY entrypoint.sh /runner
 COPY patched /runner/patched


### PR DESCRIPTION
It turned out previous versions of runner images were unable to run actions that require `AGENT_TOOLSDIRECTORY` or `libyaml` to exist in the runner environment. One of notable examples of such actions is [`ruby/setup-ruby`](https://github.com/ruby/setup-ruby).

This change adds the support for those actions, by setting up AGENT_TOOLSDIRECTORY and installing libyaml-dev within runner images.

Note that to use `ruby/setup-ruby` on the runner, you need to use the code like the below. Setting `ImageOs` env is especially important. See https://github.com/ruby/setup-ruby/issues/111 for more details.

```
    steps:
      - name: Checkout
        uses: actions/checkout@v2
      - uses: ruby/setup-ruby@v1
        with:
          ruby-version: 2.6
        env:
          ImageOS: ubuntu18
```