### PR TITLE
feat: EKS IAM Roles for Service Accounts for Runner Pods

### DIFF
--- a/acceptance/checks.sh
+++ b/acceptance/checks.sh
@@ -24,6 +24,6 @@ echo Found pod ${pod_name}.
 
 echo Waiting for pod ${runner_name} to become ready... 1>&2
 
-kubectl wait pod/${runner_name} --for condition=ready --timeout 120s
+kubectl wait pod/${runner_name} --for condition=ready --timeout 180s
 
 echo All tests passed. 1>&2

--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -32,7 +32,7 @@ else
   kubectl apply \
     -n actions-runner-system \
     -f release/actions-runner-controller.yaml
-  kubectl -n actions-runner-system wait deploy/controller-manager --for condition=available
+  kubectl -n actions-runner-system wait deploy/controller-manager --for condition=available --timeout 60s
 fi
 
 # Adhocly wait for some time until actions-runner-controller's admission webhook gets ready

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,14 +1,13 @@
 package controllers
 
-import (
-	corev1 "k8s.io/api/core/v1"
-)
+func filterLabels(labels map[string]string, filter string) map[string]string {
+	filtered := map[string]string{}
 
-func filterEnvVars(envVars []corev1.EnvVar, filter string) (filtered []corev1.EnvVar) {
-	for _, envVar := range envVars {
-		if envVar.Name != filter {
-			filtered = append(filtered, envVar)
+	for k, v := range labels {
+		if k != filter {
+			filtered[k] = v
 		}
 	}
+
 	return filtered
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -1,0 +1,34 @@
+package controllers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_filterLabels(t *testing.T) {
+	type args struct {
+		labels map[string]string
+		filter string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "ok",
+			args: args{
+				labels: map[string]string{LabelKeyRunnerTemplateHash: "abc", LabelKeyPodTemplateHash: "def"},
+				filter: LabelKeyRunnerTemplateHash,
+			},
+			want: map[string]string{LabelKeyPodTemplateHash: "def"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterLabels(tt.args.labels, tt.args.filter); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/hack/make-env.sh
+++ b/hack/make-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+COMMIT=$(git rev-parse HEAD)
+TAG=$(git describe --exact-match --abbrev=0 --tags "${COMMIT}" 2> /dev/null || true)
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | sed -e 's/[^a-zA-Z0-9+=._:/-]*//g' || true)
+VERSION=""
+
+if [ -z "$TAG" ]; then
+  [[ -n "$BRANCH" ]] && VERSION="${BRANCH}-"
+	VERSION="${VERSION}${COMMIT:0:8}"
+else
+	VERSION=$TAG
+fi
+
+if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
+    VERSION="${VERSION}-dirty"
+fi
+
+export VERSION

--- a/hash/fnv.go
+++ b/hash/fnv.go
@@ -1,0 +1,17 @@
+package hash
+
+import (
+	"fmt"
+	"hash/fnv"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func FNVHashStringObjects(objs ...interface{}) string {
+	hash := fnv.New32a()
+
+	for _, obj := range objs {
+		DeepHashObject(hash, obj)
+	}
+
+	return rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))
+}

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -1,0 +1,25 @@
+// Copyright 2015 The Kubernetes Authors.
+// hash.go is copied from kubernetes's pkg/util/hash.go
+// See https://github.com/kubernetes/kubernetes/blob/e1c617a88ec286f5f6cb2589d6ac562d095e1068/pkg/util/hash/hash.go#L25-L37
+
+package hash
+
+import (
+	"hash"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}


### PR DESCRIPTION
One of the pod recreation conditions has been modified to use hash of runner spec, so that the controller does not keep restarting pods mutated by admission webhooks.

This naturally allows us, for example, to use IRSA for EKS that requires its admission webhook to mutate the runner pod to have additional, IRSA-related volumes, volume mounts and env.

Resolves #200