### PR TITLE
Sets the docker image to use 20.10.0-dind

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	defaultRunnerImage = "summerwind/actions-runner:latest"
-	defaultDockerImage = "docker:dind"
+	defaultDockerImage = "docker:20.10.0-dind"
 )
 
 var (


### PR DESCRIPTION
As this is not yet configurable and imagePullPolicy is not set, new versions of the image do not get pulled.