### PR TITLE
Autoscaling: Percentage runners busy - remove magic number used for round up

### DIFF
--- a/controllers/autoscaling.go
+++ b/controllers/autoscaling.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -218,7 +219,7 @@ func (r *HorizontalRunnerAutoscalerReconciler) calculateReplicasByPercentageRunn
 	var desiredReplicas int
 	fractionBusy := float64(numRunnersBusy) / float64(numRunners)
 	if fractionBusy >= scaleUpThreshold {
-		scaleUpReplicas := int(float64(numRunners) * scaleUpFactor)
+		scaleUpReplicas := int(math.Ceil(float64(numRunners) * scaleUpFactor))
 		if scaleUpReplicas > maxReplicas {
 			desiredReplicas = maxReplicas
 		} else {

--- a/controllers/autoscaling.go
+++ b/controllers/autoscaling.go
@@ -218,7 +218,7 @@ func (r *HorizontalRunnerAutoscalerReconciler) calculateReplicasByPercentageRunn
 	var desiredReplicas int
 	fractionBusy := float64(numRunnersBusy) / float64(numRunners)
 	if fractionBusy >= scaleUpThreshold {
-		scaleUpReplicas := int(float64(numRunners)*scaleUpFactor + 0.5)
+		scaleUpReplicas := int(float64(numRunners) * scaleUpFactor)
 		if scaleUpReplicas > maxReplicas {
 			desiredReplicas = maxReplicas
 		} else {


### PR DESCRIPTION
Removing 0.5 used to round up any scale-up calculations to the next highest integer. This can also be accomplished by re-setting the scale-up factor.