### PR TITLE
feat/helm: add manager secret to Helm chart

### DIFF
--- a/charts/actions-runner-controller/templates/manager_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   name: controller-manager
   namespace: {{ .Release.Namespace }}
 type: Opaque
-stringData:
+data:
 {{- range $k, $v := .Values.authSecret }}
   {{ $k }}: {{ $v | toString | b64enc }}
 {{- end }} 

--- a/charts/actions-runner-controller/templates/manager_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_secrets.yaml
@@ -1,0 +1,12 @@
+{{- if or .Values.authSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-manager
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+{{- range $k, $v := .Values.authSecret }}
+  {{ $k }}: {{ $v | toString | b64enc }}
+{{- end }} 
+{{- end }}

--- a/charts/actions-runner-controller/templates/manager_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_secrets.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: controller-manager
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "actions-runner-controller.labels" . | nindent 4 }}
 type: Opaque
 data:
 {{- range $k, $v := .Values.authSecret }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -9,16 +9,16 @@ replicaCount: 1
 syncPeriod: 10m
 
 # Only 1 authentication method can be deployed at a time
-# Comment out 1 of the 2 sections and fill in
+# Uncomment the configuration you are applying and fill in
 authSecret:
   enabled: false
-  # GitHub Apps Configuration
-  github_app_id: ""
-  github_app_installation_id: ""
-  github_app_private_key: |
-      ""
-  # GitHub PAT Configuration
-  github_token: ""
+  ### GitHub Apps Configuration
+  #github_app_id: ""
+  #github_app_installation_id: ""
+  #github_app_private_key: |
+  #    ""
+  ### GitHub PAT Configuration
+  #github_token: ""
 
 image:
   repository: summerwind/actions-runner-controller

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -16,7 +16,6 @@ authSecret:
   #github_app_id: ""
   #github_app_installation_id: ""
   #github_app_private_key: |
-  #    ""
   ### GitHub PAT Configuration
   #github_token: ""
 

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -8,6 +8,18 @@ replicaCount: 1
 
 syncPeriod: 10m
 
+# Only 1 authentication method can be deployed at a time
+# Comment out 1 of the 2 sections and fill in
+authSecret:
+  enabled: false
+  # GitHub Apps Configuration
+  github_app_id: ""
+  github_app_installation_id: ""
+  github_app_private_key: |
+      ""
+  # GitHub PAT Configuration
+  github_token: ""
+
 image:
   repository: summerwind/actions-runner-controller
   # Overrides the manager image tag whose default is the chart appVersion if the tag key is commented out

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 syncPeriod: 10m
 
 # Only 1 authentication method can be deployed at a time
-# Uncomment the configuration you are applying and fill in
+# Uncomment the configuration you are applying and fill in the details
 authSecret:
   enabled: false
   ### GitHub Apps Configuration


### PR DESCRIPTION
Added the secret to Helm, worked on our cluster

**Notes**
`toString` is required to ensure we can base64 encode all secrets, incuding booleans. It doesn't however seem to work as I would expect, the  `github_app_id` and `github_app_installation_id` values had to be quoted in your `values.yaml` or you get the error `Error: Client creation failed. authentication failed: could not read private key: open : no such file or directory`.

Fixes https://github.com/summerwind/actions-runner-controller/issues/241