### PR TITLE
Add GitHub Actions to publish helm chart

### DIFF
--- a/.github/workflows/on-push-lint-charts.yml
+++ b/.github/workflows/on-push-lint-charts.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io --force-update
           helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         run: ct install --config charts/.ci/ct-config.yaml

--- a/.github/workflows/on-push-lint-charts.yml
+++ b/.github/workflows/on-push-lint-charts.yml
@@ -66,7 +66,9 @@ jobs:
 
       # We need cert-manager already installed in the cluster because we assume the CRDs exist
       - name: Install cert-manager
-        run: helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
+        run: |
+          helm repo add jetstack https://charts.jetstack.io --force-update
+          helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
 
       - name: Run chart-testing (install)
         run: ct install --config charts/.ci/ct-config.yaml

--- a/.github/workflows/on-push-lint-charts.yml
+++ b/.github/workflows/on-push-lint-charts.yml
@@ -1,0 +1,72 @@
+name: Lint and Test Charts
+
+on:
+  push:
+    paths:
+      - 'charts/**'
+      - '.github/**'
+  workflow_dispatch:
+
+env:
+  KUBE_SCORE_VERSION: 1.10.0
+  HELM_VERSION: v3.4.1
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Set up kube-score
+        run: |
+          wget https://github.com/zegl/kube-score/releases/download/v${{ env.KUBE_SCORE_VERSION }}/kube-score_${{ env.KUBE_SCORE_VERSION }}_linux_amd64 -O kube-score
+          chmod 755 kube-score
+
+      - name: Kube-score generated manifests
+        run: helm template  --values charts/.ci/values-kube-score.yaml charts/* | ./kube-score score -
+              --ignore-test pod-networkpolicy
+              --ignore-test deployment-has-poddisruptionbudget
+              --ignore-test deployment-has-host-podantiaffinity
+              --ignore-test container-security-context
+              --ignore-test pod-probes
+              --ignore-test container-image-tag
+              --enable-optional-test container-security-context-privileged
+              --enable-optional-test container-security-context-readonlyrootfilesystem
+
+      # python is a requirement for the chart-testing action below (supports yamllint among other tests)
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config charts/.ci/ct-config.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config charts/.ci/ct-config.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      # We need cert-manager already installed in the cluster because we assume the CRDs exist
+      - name: Install cert-manager
+        run: helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
+
+      - name: Run chart-testing (install)
+        run: ct install --config charts/.ci/ct-config.yaml

--- a/.github/workflows/on-push-master-publish-chart.yml
+++ b/.github/workflows/on-push-master-publish-chart.yml
@@ -1,0 +1,102 @@
+name: Publish helm chart
+
+on:
+  push:
+    branches:
+      - master
+      - main # assume that the branch name may change in future
+    paths:
+      - 'charts/**'
+      - '.github/**'
+  workflow_dispatch:
+
+env:
+  KUBE_SCORE_VERSION: 1.10.0
+  HELM_VERSION: v3.4.1
+
+jobs:
+  lint-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Set up kube-score
+        run: |
+          wget https://github.com/zegl/kube-score/releases/download/v${{ env.KUBE_SCORE_VERSION }}/kube-score_${{ env.KUBE_SCORE_VERSION }}_linux_amd64 -O kube-score
+          chmod 755 kube-score
+
+      - name: Kube-score generated manifests
+        run: helm template  --values charts/.ci/values-kube-score.yaml charts/* | ./kube-score score -
+              --ignore-test pod-networkpolicy
+              --ignore-test deployment-has-poddisruptionbudget
+              --ignore-test deployment-has-host-podantiaffinity
+              --ignore-test container-security-context
+              --ignore-test pod-probes
+              --ignore-test container-image-tag
+              --enable-optional-test container-security-context-privileged
+              --enable-optional-test container-security-context-readonlyrootfilesystem
+
+      # python is a requirement for the chart-testing action below (supports yamllint among other tests)
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config charts/.ci/ct-config.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config charts/.ci/ct-config.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config charts/.ci/ct-config.yaml
+
+  publish-chart:
+
+    runs-on: ubuntu-latest
+    needs: lint-chart
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # We need cert-manager already installed in the cluster because we assume the CRDs exist
+      - name: Install cert-manager
+        run: helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/on-push-master-publish-chart.yml
+++ b/.github/workflows/on-push-master-publish-chart.yml
@@ -93,7 +93,9 @@ jobs:
 
       # We need cert-manager already installed in the cluster because we assume the CRDs exist
       - name: Install cert-manager
-        run: helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
+        run: |
+          helm repo add jetstack https://charts.jetstack.io --force-update
+          helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0

--- a/.github/workflows/on-push-master-publish-chart.yml
+++ b/.github/workflows/on-push-master-publish-chart.yml
@@ -67,6 +67,12 @@ jobs:
         uses: helm/kind-action@v1.0.0
         if: steps.list-changed.outputs.changed == 'true'
 
+      # We need cert-manager already installed in the cluster because we assume the CRDs exist
+      - name: Install cert-manager
+        run: |
+          helm repo add jetstack https://charts.jetstack.io --force-update
+          helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
+
       - name: Run chart-testing (install)
         run: ct install --config charts/.ci/ct-config.yaml
 
@@ -85,17 +91,6 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      # We need cert-manager already installed in the cluster because we assume the CRDs exist
-      - name: Install cert-manager
-        run: |
-          helm repo add jetstack https://charts.jetstack.io --force-update
-          helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0

--- a/charts/.ci/ct-config.yaml
+++ b/charts/.ci/ct-config.yaml
@@ -1,0 +1,4 @@
+# This file defines the config for "ct" (chart tester) used by the helm linting GitHub workflow
+lint-conf: charts/.ci/lint-config.yaml
+chart-repos:
+  - jetstack=https://charts.jetstack.io

--- a/charts/.ci/lint-config.yaml
+++ b/charts/.ci/lint-config.yaml
@@ -1,0 +1,6 @@
+rules:
+  # One blank line is OK
+  empty-lines: 
+    max-start: 1
+    max-end: 1
+    max: 1

--- a/charts/.ci/scripts/local-ct-lint.sh
+++ b/charts/.ci/scripts/local-ct-lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -it -w /repo -v $(pwd):/repo quay.io/helmpack/chart-testing ct lint --all --config charts/.ci/ct-config.yaml

--- a/charts/.ci/scripts/local-kube-score.sh
+++ b/charts/.ci/scripts/local-kube-score.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+for chart in `ls charts`;
+do
+helm template --values charts/$chart/ci/ci-values.yaml charts/$chart | kube-score score - \
+    --ignore-test pod-networkpolicy \
+    --ignore-test deployment-has-poddisruptionbudget \
+    --ignore-test deployment-has-host-podantiaffinity \
+    --ignore-test pod-probes \
+    --ignore-test container-image-tag \
+    --enable-optional-test container-security-context-privileged \
+    --enable-optional-test container-security-context-readonlyrootfilesystem \
+    --ignore-test container-security-context
+done

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,9 +15,22 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.11.2
+appVersion: 0.16.0
+
+home: https://github.com/summerwind/actions-runner-controller
+
+sources:
+    - https://github.com/summerwind/actions-runner-controller
+
+maintainers:
+    - name: summerwind
+      email: contact@summerwind.jp
+      url: https://github.com/summerwind
+    - name: funkypenguin
+      email: davidy@funkypenguin.co.nz
+      url: https://www.funkypenguin.co.nz

--- a/charts/actions-runner-controller/ci/ci-values.yaml
+++ b/charts/actions-runner-controller/ci/ci-values.yaml
@@ -1,0 +1,27 @@
+# This file sets some opinionated values for kube-score to use
+# when parsing the chart
+image:
+  pullPolicy: Always
+
+podSecurityContext:
+  fsGroup: 2000
+
+securityContext: 
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 2000
+
+resources: 
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi  
+
+# Set the following to true to create a dummy secret, allowing the manager pod to start
+# This is only useful in CI
+createDummySecret: true

--- a/charts/actions-runner-controller/templates/_helpers.tpl
+++ b/charts/actions-runner-controller/templates/_helpers.tpl
@@ -89,7 +89,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "actions-runner-controller.authProxyServiceName" -}}
-{{- include "actions-runner-controller.fullname" . }}-controller-manager-metrics-service
+{{- include "actions-runner-controller.fullname" . }}-metrics-service
 {{- end }}
 
 {{- define "actions-runner-controller.selfsignedIssuerName" -}}

--- a/charts/actions-runner-controller/templates/ci-secret.yaml
+++ b/charts/actions-runner-controller/templates/ci-secret.yaml
@@ -1,0 +1,10 @@
+# This template only exists to facilitate CI testing of the chart, since
+# a secret is expected to be found in the namespace by the controller manager
+{{ if .Values.createDummySecret -}}
+apiVersion: v1
+data:
+  github_token: dGVzdA==
+kind: Secret
+metadata:
+  name: controller-manager
+{{- end }}

--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=10"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: "{{ .Values.kube_rbac_proxy.image.repository }}:{{ .Values.kube_rbac_proxy.image.tag }}"
         name: kube-rbac-proxy
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:

--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -66,10 +66,14 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}          
         volumeMounts:
         - mountPath: "/etc/actions-runner-controller"
           name: controller-manager
           readOnly: true
+        - mountPath: /tmp
+          name: tmp         
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -80,9 +84,14 @@ spec:
         - "--v=10"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
         name: kube-rbac-proxy
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 8443
           name: https
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}   
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}     
       terminationGracePeriodSeconds: 10
       volumes:
       - name: controller-manager
@@ -92,6 +101,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
+      - name: tmp
+        emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -87,3 +87,7 @@ affinity: {}
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # PriorityClass: system-cluster-critical
 priorityClassName: ""
+
+# Set the following to true to install cert-manager as a requirement to this chart
+certmanager:
+  enabled: false

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -15,6 +15,11 @@ image:
   dindSidecarRepositoryAndTag: "docker:dind"
   pullPolicy: IfNotPresent
 
+kube_rbac_proxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    tag: v0.4.1
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -87,7 +87,3 @@ affinity: {}
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # PriorityClass: system-cluster-critical
 priorityClassName: ""
-
-# Set the following to true to install cert-manager as a requirement to this chart
-certmanager:
-  enabled: false


### PR DESCRIPTION
Hey @summerwind!

Here's a PR for some GitHub actions I commonly use to test and publish helm charts using GitHub pages. If you create a branch `gh-pages`, then the action will publish your helm chart at https://summerwind.github.io/action-runner-controller (_you can see https://geek-cookbook.github.io/actions-runner-controller for an example_)

I've also made a handful of improvements to the helm chart to support kube-score static analysis, and chart linting/publishing via the helm "ct" tool.

Happy to field suggestions / change requests! :)

Cheers!
D