### PR TITLE
GitHub runner groups have to be created first

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Note that if you specify `self-hosted` in your workflow, then this will run your
 
 ## Runner Groups
 
-Runner groups can be used to limit which repositories are able to use the GitHub Runner at an Organisation level.
+Runner groups can be used to limit which repositories are able to use the GitHub Runner at an Organisation level. Runner groups have to be [created in GitHub first](https://docs.github.com/en/actions/hosting-your-own-runners/managing-access-to-self-hosted-runners-using-groups) before they can be referenced.
 
 To add the runner to the group `NewGroup`, specify the group in your `Runner` or `RunnerDeployment` spec.
 


### PR DESCRIPTION
* in contrast to runner labels, GitHub runner groups are not automatically created