### PR TITLE
feat/helm: Bump appVersion to 0.6.1 release

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -20,7 +20,7 @@ version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.16.0
+appVersion: 0.16.1
 
 home: https://github.com/summerwind/actions-runner-controller
 


### PR DESCRIPTION
Bump `appVersion` to `0.6.1` [release](https://github.com/summerwind/actions-runner-controller/releases/tag/v0.16.1)