### PR TITLE
Update GitHub Runner version

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -27,7 +27,7 @@ jobs:
           - name: actions-runner-dind
             dockerfile: dindrunner.Dockerfile
     env:
-      RUNNER_VERSION: 2.275.1
+      RUNNER_VERSION: 2.276.1
       DOCKER_VERSION: 19.03.12
       DOCKERHUB_USERNAME: ${{ github.repository_owner }}
     steps:


### PR DESCRIPTION
Update to GitHub Runner version [`2.276.1`](https://github.com/actions/runner/releases/tag/v2.276.1).

Might as well prevent an auto update for a while 😄 