### PR TITLE
fix: Paginate ListRepositoryWorkflowRuns

### DIFF
--- a/controllers/autoscaling.go
+++ b/controllers/autoscaling.go
@@ -138,12 +138,12 @@ func (r *HorizontalRunnerAutoscalerReconciler) calculateReplicasByQueuedAndInPro
 
 	for _, repo := range repos {
 		user, repoName := repo[0], repo[1]
-		list, _, err := r.GitHubClient.Actions.ListRepositoryWorkflowRuns(context.TODO(), user, repoName, nil)
+		workflowRuns, err := r.GitHubClient.ListRepositoryWorkflowRuns(context.TODO(), user, repoName)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, run := range list.WorkflowRuns {
+		for _, run := range workflowRuns {
 			total++
 
 			// In May 2020, there are only 3 statuses.


### PR DESCRIPTION
When we used `QueuedAndInProgressWorkflowRuns`-based autoscaling, it only fetched and considered only the first 30 workflow runs at the reconcilation time. This may have resulted in unreliable scaling behaviour, like scale-in/out not happening when it was expected.