### PR TITLE
Pod eviction policy examples to not wait 400 seconds until runner controller creates new pods for crashed nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,14 @@ spec:
         requests:
           cpu: "2.0"
           memory: "4Gi"
+      
+      # Timeout after a node crashed or became unreachable to evict your pods somewhere else (default 5mins)
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 10
+          
       # If set to false, there are no privileged container and you cannot use docker.
       dockerEnabled: false
       # If set to true, runner pod container only 1 container that's expected to be able to run docker, too.


### PR DESCRIPTION
* ... otherwise it will take 40 seconds (until a node is detected as unreachable) + 5 minutes (until pods are evicted from unreachable/crashed nodes)
* pods stuck in "Terminating" status on unreachable nodes will only be freed once #307 gets merged (with a timeout of another minute)