### PR TITLE
Fix rate limit and runner not registered detection logic and action

### DIFF
--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -212,16 +212,18 @@ func (r *RunnerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			return ctrl.Result{}, err
 		}
 
-		var notRegistered bool
+		notRegistered := false
 
 		runnerBusy, err := r.GitHubClient.IsRunnerBusy(ctx, runner.Spec.Enterprise, runner.Spec.Organization, runner.Spec.Repository, runner.Name)
 		if err != nil {
-			if errors.Is(err, github.RunnerNotFound{}) {
+			var e *github.RunnerNotFound
+			if errors.As(err, &e) {
 				log.Error(err, "Failed to check if runner is busy. Probably this runner has never been successfully registered to GitHub.")
 
 				notRegistered = true
 			} else {
-				if errors.Is(err, &gogithub.RateLimitError{}) {
+				var e *gogithub.RateLimitError
+				if errors.As(err, &e) {
 					// We log the underlying error when we failed calling GitHub API to list or unregisters,
 					// or the runner is still busy.
 					log.Error(
@@ -252,7 +254,7 @@ func (r *RunnerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		currentTime := time.Now()
 		registrationDidTimeout := currentTime.Sub(pod.CreationTimestamp.Add(registrationTimeout)) > 0
 
-		if !notRegistered && registrationDidTimeout {
+		if notRegistered && registrationDidTimeout {
 			log.Info(
 				"Runner failed to register itself to GitHub in timely manner. "+
 					"Recreating the pod to see if it resolves the issue. "+

--- a/github/github.go
+++ b/github/github.go
@@ -287,7 +287,7 @@ type RunnerNotFound struct {
 	runnerName string
 }
 
-func (e RunnerNotFound) Error() string {
+func (e *RunnerNotFound) Error() string {
 	return fmt.Sprintf("runner %q not found", e.runnerName)
 }
 
@@ -303,5 +303,5 @@ func (r *Client) IsRunnerBusy(ctx context.Context, enterprise, org, repo, name s
 		}
 	}
 
-	return false, RunnerNotFound{runnerName: name}
+	return false, &RunnerNotFound{runnerName: name}
 }


### PR DESCRIPTION
* in the changes introduced by #297   - conditions to detect not found runners or rate limit exceptions have never been triggered because `errors.Is` compares all members of a struct to return true which never happened
* switched to type check instead of exact value check and use references instead of copying values

* in changes introduced by #297 runners have been deregistered all 10 minutes (de-registration timeout), no matter whether they have failed to register or not because the if statement checking notRegistered was using double negation in if statement which lead to deregistration in all cases
* changed if statement to only deregister if actually needed and cleaned up error messages and detection logic in replicaset and runner controllers