### PR TITLE
fix: duplicate name attribute in workflow

### DIFF
--- a/.github/workflows/build-and-release-runners.yml
+++ b/.github/workflows/build-and-release-runners.yml
@@ -18,7 +18,7 @@ on:
       - .github/workflows/build-runner.yml
   release:
     types: [published]
-name: Runner
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
workflow failing due to duplicate workflow `Name` attribute