### PR TITLE
fix: add trunate to ensure service kinds have valid names

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 home: https://github.com/summerwind/actions-runner-controller
 

--- a/charts/actions-runner-controller/templates/_helpers.tpl
+++ b/charts/actions-runner-controller/templates/_helpers.tpl
@@ -85,11 +85,11 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "actions-runner-controller.webhookServiceName" -}}
-{{- include "actions-runner-controller.fullname" . }}-webhook
+{{- include "actions-runner-controller.fullname" . | trunc 55 }}-webhook
 {{- end }}
 
 {{- define "actions-runner-controller.authProxyServiceName" -}}
-{{- include "actions-runner-controller.fullname" . }}-metrics-service
+{{- include "actions-runner-controller.fullname" . | trunc 47 }}-metrics-service
 {{- end }}
 
 {{- define "actions-runner-controller.selfsignedIssuerName" -}}


### PR DESCRIPTION
Fixes https://github.com/summerwind/actions-runner-controller/issues/324

**Tests**
Installed the controller on minikube with the change and no `fullnameOverride` or `nameOverride` specificed in the `values.yaml` as well as a really long string specified for `fullnameOverride`. No errors in the `kubectl logs` in the case of `actions-actions-runner-controller-66984955f9-fg495` but I got a weird can't find the pod error with the weird pod name deployment. The pod was running fine though 🤷‍♂️ . I put it down to the ridiclously long name that isn't realistic in the real world.

```shell
NAME                                                 READY   STATUS    RESTARTS   AGE
actions-actions-runner-controller-66984955f9-fg495   2/2     Running   0          84s
```

```shell
NAME                                                              READY   STATUS    RESTARTS   AGE
asdjbksakbdfjksabfdjkbfdkjsbfdskbfdskbfkdsbfuidsgfuidsgfdugkpdf   2/2     Running   0          11s
```