### PR TITLE
Also log into DockerHub for release event

### DIFF
--- a/.github/workflows/build-and-release-runners.yml
+++ b/.github/workflows/build-and-release-runners.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}


### PR DESCRIPTION
* so far, only push events would trigger the DockerHub login step
* hence, attempts to release would fail because of a permission problem (tested locally)
* adding OR condition to also login in case a release got published