### PR TITLE
Fix manifest of github-webhook-server

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 home: https://github.com/summerwind/actions-runner-controller
 

--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -52,7 +52,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 8000
-          name: github-webhook-server
+          name: http
           protocol: TCP
         resources:
           {{- toYaml .Values.githubWebhookServer.resources | nindent 12 }}

--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -32,7 +32,6 @@ spec:
       containers:
       - args:
         - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
         - "--sync-period={{ .Values.githubWebhookServer.syncPeriod }}"
         command:
         - "/github-webhook-server"

--- a/charts/actions-runner-controller/templates/githubwebhook.role_binding.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.role_binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.githubWebhookServer.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "actions-runner-controller-github-webhook-server.roleName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "actions-runner-controller-github-webhook-server.roleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "actions-runner-controller-github-webhook-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -147,7 +147,7 @@ githubWebhookServer:
     type: NodePort
     ports:
     - port: 80
-      targetPort: 8000
+      targetPort: http
       protocol: TCP
       name: http
       #nodePort: someFixedPortForUseWithTerraformCdkCfnEtc


### PR DESCRIPTION
Hello,

I tried the new release of helm chart https://github.com/summerwind/actions-runner-controller/releases/tag/actions-runner-controller-0.5.1 in our cluster and found some errors. This PR contains:

1. Fix length of github-webhook-server port name
2. Add a cluster role binding for github-webhook-server
3. Remove --enable-leader-election from github-webhook-server

### (1) Fix length of github-webhook-server port name

I got the following error during deploy:

```
Deployment.apps "actions-runner-controller-github-webhook-server" is invalid: spec.template.spec.containers[0].ports[0].name: Invalid value: "github-webhook-server": must be no more than 15 characters
```

I have applied the following JSON patch and now it works:

```yaml
- op: replace
  path: /spec/template/spec/containers/0/ports/0/name
  value: http
```

### (2) Add a cluster role binding for github-webhook-server

I got the following error in webhook-server:

```
E0218 04:43:51.293033       1 reflector.go:123] pkg/mod/k8s.io/client-go@v0.0.0-20190918160344-1fbdaa4c8d90/tools/cache/reflector.go:96: Failed to list *v1alpha1.HorizontalRunnerAutoscaler: horizontalrunnerautoscalers.actions.summerwind.dev is forbidden: User "system:serviceaccount:actions-runner-system:actions-runner-controller-github-webhook-server" cannot list resource "horizontalrunnerautoscalers" in API group "actions.summerwind.dev" at the cluster scope
```

I added the following resource and the error has been resolved:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: actions-runner-controller-github-webhook-server
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: actions-runner-controller-github-webhook-server
subjects:
- kind: ServiceAccount
  name: actions-runner-controller-github-webhook-server
  namespace: actions-runner-system
```

### (3) Remove --enable-leader-election from github-webhook-server

I got the following error in webhook-server:

```
E0218 04:43:48.331290       1 leaderelection.go:330] error retrieving resource lock actions-runner-system/controller-leader-election-helper: configmaps "controller-leader-election-helper" is forbidden: User "system:serviceaccount:actions-runner-system:actions-runner-controller-github-webhook-server" cannot get resource "configmaps" in API group "" in the namespace "actions-runner-system
```

I think both controller-manager and github-webhook-server cannot share the config map for leader election. This PR just removes `--enable-leader-election` from github-webhook-server but please tell me if you know better way.


Thank you for the great work.