### PR TITLE
Fix index key to find HRA in GitHub webhook handler

### DIFF
--- a/controllers/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/horizontal_runner_autoscaler_webhook.go
@@ -303,17 +303,20 @@ func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) getScaleTarget(ctx co
 }
 
 func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) getScaleUpTarget(ctx context.Context, repoNameFromWebhook, orgNameFromWebhook string, f func(v1alpha1.ScaleUpTrigger) bool) (*ScaleTarget, error) {
-	if target, err := autoscaler.getScaleTarget(ctx, repoNameFromWebhook, f); err != nil {
+	repositoryRunnerKey := orgNameFromWebhook + "/" + repoNameFromWebhook
+	autoscaler.Log.Info("finding repository-wide runner", "repository", repositoryRunnerKey)
+	if target, err := autoscaler.getScaleTarget(ctx, repositoryRunnerKey, f); err != nil {
 		return nil, err
 	} else if target != nil {
 		autoscaler.Log.Info("scale up target is repository-wide runners", "repository", repoNameFromWebhook)
 		return target, nil
 	}
 
+	autoscaler.Log.Info("finding organizational runner", "organization", orgNameFromWebhook)
 	if target, err := autoscaler.getScaleTarget(ctx, orgNameFromWebhook, f); err != nil {
 		return nil, err
 	} else if target != nil {
-		autoscaler.Log.Info("scale up target is organizational runners", "repository", orgNameFromWebhook)
+		autoscaler.Log.Info("scale up target is organizational runners", "organization", orgNameFromWebhook)
 		return target, nil
 	}
 

--- a/controllers/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/horizontal_runner_autoscaler_webhook.go
@@ -56,6 +56,7 @@ type HorizontalRunnerAutoscalerGitHubWebhook struct {
 	// scaled on Webhook.
 	// Set to empty for letting it watch for all namespaces.
 	WatchNamespace string
+	Name           string
 }
 
 func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) Reconcile(request reconcile.Request) (reconcile.Result, error) {
@@ -350,6 +351,10 @@ func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) tryScaleUp(ctx contex
 
 func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) SetupWithManager(mgr ctrl.Manager) error {
 	name := "webhookbasedautoscaler"
+	if autoscaler.Name != "" {
+		name = autoscaler.Name
+	}
+
 	autoscaler.Recorder = mgr.GetEventRecorderFor(name)
 
 	if err := mgr.GetFieldIndexer().IndexField(&v1alpha1.HorizontalRunnerAutoscaler{}, scaleTargetKey, func(rawObj runtime.Object) []string {

--- a/controllers/horizontalrunnerautoscaler_controller.go
+++ b/controllers/horizontalrunnerautoscaler_controller.go
@@ -48,6 +48,7 @@ type HorizontalRunnerAutoscalerReconciler struct {
 	Scheme       *runtime.Scheme
 
 	CacheDuration time.Duration
+	Name          string
 }
 
 // +kubebuilder:rbac:groups=actions.summerwind.dev,resources=runnerdeployments,verbs=get;list;watch;update;patch
@@ -184,6 +185,10 @@ func (r *HorizontalRunnerAutoscalerReconciler) Reconcile(req ctrl.Request) (ctrl
 
 func (r *HorizontalRunnerAutoscalerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	name := "horizontalrunnerautoscaler-controller"
+	if r.Name != "" {
+		name = r.Name
+	}
+
 	r.Recorder = mgr.GetEventRecorderFor(name)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"time"
 
 	"github.com/summerwind/actions-runner-controller/github/fake"
@@ -297,14 +296,14 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 
 			// Scale-up to 2 replicas on first pull_request create webhook event
 			{
-				env.SendPullRequestEvent("test/valid", "main", "created")
+				env.SendPullRequestEvent("test", "valid", "main", "created")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1, "runner sets after webhook")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 2, "runners after first webhook event")
 			}
 
 			// Scale-up to 3 replicas on second pull_request create webhook event
 			{
-				env.SendPullRequestEvent("test/valid", "main", "created")
+				env.SendPullRequestEvent("test", "valid", "main", "created")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3, "runners after second webhook event")
 			}
 		})
@@ -386,7 +385,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 
 			// Scale-up to 4 replicas on first check_run create webhook event
 			{
-				env.SendCheckRunEvent("test/valid", "pending", "created")
+				env.SendCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1, "runner sets after webhook")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 4, "runners after first webhook event")
 			}
@@ -397,7 +396,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 
 			// Scale-up to 5 replicas on second check_run create webhook event
 			{
-				env.SendCheckRunEvent("test/valid", "pending", "created")
+				env.SendCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 5, "runners after second webhook event")
 			}
 
@@ -420,9 +419,7 @@ func (env *testEnvironment) ExpectRegisteredNumberCountEventuallyEquals(want int
 		time.Second*1, time.Millisecond*500).Should(Equal(want), optionalDescriptions...)
 }
 
-func (env *testEnvironment) SendPullRequestEvent(repo string, branch string, action string) {
-	org := strings.Split(repo, "/")[0]
-
+func (env *testEnvironment) SendPullRequestEvent(org, repo, branch, action string) {
 	resp, err := sendWebhook(env.webhookServer, "pull_request", &github.PullRequestEvent{
 		PullRequest: &github.PullRequest{
 			Base: &github.PullRequestBranch{
@@ -443,9 +440,7 @@ func (env *testEnvironment) SendPullRequestEvent(repo string, branch string, act
 	ExpectWithOffset(1, resp.StatusCode).To(Equal(200))
 }
 
-func (env *testEnvironment) SendCheckRunEvent(repo string, status string, action string) {
-	org := strings.Split(repo, "/")[0]
-
+func (env *testEnvironment) SendCheckRunEvent(org, repo, status, action string) {
 	resp, err := sendWebhook(env.webhookServer, "check_run", &github.CheckRunEvent{
 		CheckRun: &github.CheckRun{
 			Status: github.String(status),

--- a/controllers/runnerdeployment_controller.go
+++ b/controllers/runnerdeployment_controller.go
@@ -52,6 +52,7 @@ type RunnerDeploymentReconciler struct {
 	Recorder           record.EventRecorder
 	Scheme             *runtime.Scheme
 	CommonRunnerLabels []string
+	Name               string
 }
 
 // +kubebuilder:rbac:groups=actions.summerwind.dev,resources=runnerdeployments,verbs=get;list;watch;create;update;patch;delete
@@ -291,6 +292,10 @@ func (r *RunnerDeploymentReconciler) newRunnerReplicaSet(rd v1alpha1.RunnerDeplo
 
 func (r *RunnerDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	name := "runnerdeployment-controller"
+	if r.Name != "" {
+		name = r.Name
+	}
+
 	r.Recorder = mgr.GetEventRecorderFor(name)
 
 	if err := mgr.GetFieldIndexer().IndexField(&v1alpha1.RunnerReplicaSet{}, runnerSetOwnerKey, func(rawObj runtime.Object) []string {

--- a/controllers/runnerreplicaset_controller.go
+++ b/controllers/runnerreplicaset_controller.go
@@ -44,6 +44,7 @@ type RunnerReplicaSetReconciler struct {
 	Recorder     record.EventRecorder
 	Scheme       *runtime.Scheme
 	GitHubClient *github.Client
+	Name         string
 }
 
 // +kubebuilder:rbac:groups=actions.summerwind.dev,resources=runnerreplicasets,verbs=get;list;watch;create;update;patch;delete
@@ -222,6 +223,10 @@ func (r *RunnerReplicaSetReconciler) newRunner(rs v1alpha1.RunnerReplicaSet) (v1
 
 func (r *RunnerReplicaSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	name := "runnerreplicaset-controller"
+	if r.Name != "" {
+		name = r.Name
+	}
+
 	r.Recorder = mgr.GetEventRecorderFor(name)
 
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
## Problem to solve

I tried the canary version in our cluster but actually GitHub webhook event did not trigger scale up of the HRA. I added some logs to the webhook handler and finally it turned out the handler tried to find HRAs by the wrong key.

Here are my investigation logs:

```
2021-02-20T10:50:04.371Z	INFO	controllers.Runner	indexing	{"hra": "kubernetes-clusters", "keys": ["MYORG/MYREPO", ""]}
...
2021-02-20T10:52:01.432Z	INFO	controllers.Runner	processing webhook event	{"eventType": "check_run"}
2021-02-20T10:52:01.432Z	INFO	controllers.Runner	finding HRAs by key	{"key": "MYREPO"}
2021-02-20T10:52:01.433Z	INFO	controllers.Runner	finding HRAs by key	{"key": "MYORG"}
2021-02-20T10:52:01.433Z	INFO	controllers.Runner	no horizontalrunnerautoscaler to scale for this github event	{"eventType": "check_run"}
```

## What this PR does

- Include the integration test https://github.com/summerwind/actions-runner-controller/pull/334, thanks @mumoshu 
- Fix the integration test in dfbe53d. Request should be in the form of `MYREPO` and was `MYORG/MYREPO`
- Fix the implementation in b0e74be. It changes to find the repository-wide runners by `MYORG/MYREPO`

## Test

I have deployed this commit to our cluster and verified that the handler triggered scale up:

```
2021-02-20T12:46:16.287Z	INFO	controllers.Runner	processing webhook event	{"eventType": "check_run"}
2021-02-20T12:46:16.287Z	INFO	controllers.Runner	finding repository-wide runner	{"repository": "MYORG/MYREPO"}
2021-02-20T12:46:16.287Z	INFO	controllers.Runner	scale up target is repository-wide runners	{"repository": "MYREPO"}
2021-02-20T12:46:16.304Z	INFO	controllers.Runner	scaled MYDEPLOYMENT by 1
```


I hope this PR will fix the webhook based autoscaling.