### PR TITLE
Avoid zombie runners that missed token expiration by a bit

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -85,7 +85,10 @@ func (c *Client) GetRegistrationToken(ctx context.Context, enterprise, org, repo
 	key := getRegistrationKey(org, repo, enterprise)
 	rt, ok := c.regTokens[key]
 
-	if ok && rt.GetExpiresAt().After(time.Now()) {
+	// we like to give runners a chance that are just starting up and may miss the expiration date by a bit
+	runnerStartupTimeout := 3 * time.Minute
+
+	if ok && rt.GetExpiresAt().After(time.Now().Add(runnerStartupTimeout)) {
 		return rt, nil
 	}
 


### PR DESCRIPTION
* if a new runner pod was just scheduled to start up right before a 
registration token expired, it will not get a new registration token and go in 
an infinite update loop (until #341 kicks in)
* if registration tokens got updated a little bit before they actually 
expired, just starting up pods will way more likely get a working token