### PR TITLE
Fix runner release workflow to do docker-push

### DIFF
--- a/.github/workflows/build-and-release-runners.yml
+++ b/.github/workflows/build-and-release-runners.yml
@@ -61,6 +61,7 @@ jobs:
           context: ./runner
           file: ./runner/${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             RUNNER_VERSION=${{ env.RUNNER_VERSION }}
             DOCKER_VERSION=${{ env.DOCKER_VERSION }}


### PR DESCRIPTION
Apparently I have mistakenly removed `push` option from the workflow in #323 which resulted in new runner build #323 not being pushed. This fixes that.