### PR TITLE
Set default python

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -37,6 +37,7 @@ RUN apt update -y \
   wget \
   zip \
   zstd \
+  && cd /usr/bin && ln -sf python3 python \
   && rm -rf /var/lib/apt/lists/*
 
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/dindrunner.Dockerfile
+++ b/runner/dindrunner.Dockerfile
@@ -21,6 +21,7 @@ RUN apt update \
     netcat \
     openssh-client \
     parallel \
+    python-is-python3 \
     rsync \
     shellcheck \
     sudo \


### PR DESCRIPTION
The Actions documentation states that `python` is  a supported shell for `run:` commands. However, this isn't working as the default python command/symlink is missing although Python 3 packages are installed via dependencies.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-running-a-python-script

The following step fails without the patch due to the `Invalid shell option. Shell must be a valid built-in (bash, sh, cmd, powershell, pwsh) or a format string containing '{0}'` error. Yes, [python](https://github.com/actions/runner/blob/c18c8746db0b7662a13da5596412c05c1ffb07dd/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs#L16) is defined although the error message states otherwise:
```
    - name: Display the path
      run: |
        import os
        print(os.environ['PATH'])
      shell: python
```

Ofcourse, this can be circumvented by defining `shell: python3 {0}`, but sticking to the default documentation is better.

The DinD runner is based on newer Ubuntu 20.04 that has already a neat [package](https://packages.ubuntu.com/focal/python/python-is-python3) available for this purpose.
