### PR TITLE
Fix helm template error when webhook server is enabled

### DIFF
--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -41,7 +41,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: github_webhook_secret_token
-              name: {{- include "actions-runner-controller-github-webhook-server.secretName" . }}
+              name: {{ include "actions-runner-controller-github-webhook-server.secretName" . }}
               optional: true
         {{- range $key, $val := .Values.githubWebhookServer.env }}
         - name: {{ $key }}

--- a/charts/actions-runner-controller/templates/githubwebhook.secrets.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{- include "actions-runner-controller-github-webhook-server.secretName" . }}
+  name: {{ include "actions-runner-controller-github-webhook-server.secretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "actions-runner-controller.labels" . | nindent 4 }}


### PR DESCRIPTION
I got the following error with the latest chart (v0.6.0):

```console
% git clone https://github.com/summerwind/actions-runner-controller
% cd charts/actions-runner-controller

% helm template test . --set githubWebhookServer.enabled=true
Error: YAML parse error on actions-runner-controller/templates/githubwebhook.deployment.yaml: error converting YAML to JSON: yaml: line 38: could not find expected ':'
```

I fixed the deployment as af6bb9e but still got the following error:

```console
% helm template test . --set githubWebhookServer.enabled=true
Error: YAML parse error on actions-runner-controller/templates/githubwebhook.secrets.yaml: error converting YAML to JSON: yaml: line 5: mapping values are not allowed in this context
```

This PR will fix these errors.
