### PR TITLE
Set runner group for runners with enterprise scope

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -40,7 +40,7 @@ if [ -z "${RUNNER_TOKEN}" ]; then
   exit 1
 fi
 
-if [ -z "${RUNNER_REPO}" ] && [ -n "${RUNNER_ORG}" ] && [ -n "${RUNNER_GROUP}" ];then
+if [ -z "${RUNNER_REPO}" ] && [ -n "${RUNNER_GROUP}" ];then
   RUNNER_GROUP_ARG="--runnergroup ${RUNNER_GROUP}"
 fi
 


### PR DESCRIPTION
* so far, runner group parameter is only set for runners with org scope
* now set group for enterprise runners as well
* removed null check for org scope as either org or enterprise will be set