### PR TITLE
handle GET requests in webhook hra

### DIFF
--- a/controllers/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/horizontal_runner_autoscaler_webhook.go
@@ -95,6 +95,12 @@ func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) Handle(w http.Respons
 		}
 	}()
 
+	// respond ok to GET / e.g. for health check
+	if r.Method == http.MethodGet {
+		fmt.Fprintln(w, "webhook server is running")
+		return
+	}
+
 	var payload []byte
 
 	if len(autoscaler.SecretKeyBytes) > 0 {

--- a/controllers/horizontal_runner_autoscaler_webhook_test.go
+++ b/controllers/horizontal_runner_autoscaler_webhook_test.go
@@ -113,6 +113,19 @@ func TestWebhookPing(t *testing.T) {
 	)
 }
 
+func TestGetRequest(t *testing.T) {
+	hra := HorizontalRunnerAutoscalerGitHubWebhook{}
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.ResponseRecorder{}
+
+	hra.Handle(&recorder, request)
+	response := recorder.Result()
+
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("want %d, got %d", http.StatusOK, response.StatusCode)
+	}
+}
+
 func TestGetValidCapacityReservations(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
Hi,

The logs of the webhook controller show an error every 30secs, I guess due to a health check request which fails to be parsed as a GitHub event.

```
2021-03-08T14:41:55.562Z	ERROR	controllers.Runner	error validating request body	{"error": "Webhook request has unsupported Content-Type \"\""}
2021-03-08T14:42:25.556Z	ERROR	controllers.Runner	error validating request body	{"error": "Webhook request has unsupported Content-Type \"\""}
2021-03-08T14:42:55.558Z	ERROR	controllers.Runner	error validating request body	{"error": "Webhook request has unsupported Content-Type \"\""}
```

Currently the handler assumes all requests are `POST`s from GitHub, this PR changes it to return early with `200 OK` for any `GET` request.
