### PR TITLE
Fix wildcard in middle of actionsglob/scaleUpTrigger.githubEvent.checkRun.names not working

### DIFF
--- a/pkg/actionsglob/actionsglob.go
+++ b/pkg/actionsglob/actionsglob.go
@@ -65,7 +65,7 @@ func Match(pat string, s string) bool {
 
 		s = subs[1]
 
-		wildcardInHead = false
+		wildcardInHead = wildcardInTail
 	}
 
 	r := s == ""

--- a/pkg/actionsglob/match_test.go
+++ b/pkg/actionsglob/match_test.go
@@ -195,4 +195,20 @@ func TestMatch(t *testing.T) {
 			Want:    false,
 		})
 	})
+
+	t.Run("actions-*-metrics == actions-workflow-metrics", func(t *testing.T) {
+		run(t, testcase{
+			Pattern: "actions-*-metrics",
+			Target:  "actions-workflow-metrics",
+			Want:    true,
+		})
+	})
+
+	t.Run("!actions-*-metrics == actions-workflow-metrics", func(t *testing.T) {
+		run(t, testcase{
+			Pattern: "!actions-*-metrics",
+			Target:  "actions-workflow-metrics",
+			Want:    false,
+		})
+	})
 }


### PR DESCRIPTION
actionsglob patterns like `foo-*-bar` was not correctly working. Tests and the implementation was enhanced to correctly support it.