### PR TITLE
Fix typo in certificate.yaml

### DIFF
--- a/charts/actions-runner-controller/templates/certificate.yaml
+++ b/charts/actions-runner-controller/templates/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "actions-runner-controller.selfsignedIssuerName" . }}
-  namespace: {{ .Namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 ---
@@ -13,7 +13,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "actions-runner-controller.servingCertName" . }}
-  namespace: {{ .Namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - {{ include "actions-runner-controller.webhookServiceName" . }}.{{ .Release.Namespace }}.svc


### PR DESCRIPTION
Fix typo in certificate.yaml: `{{ .Namespace }}` -> `{{ .Release.Namespace }}`