### PR TITLE
Fix `status.lastRegistrationCheckTime in body must be of type string: \"null\"` errors

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -130,6 +130,7 @@ type RunnerStatus struct {
 	// +optional
 	Message string `json:"message,omitempty"`
 	// +optional
+	// +nullable
 	LastRegistrationCheckTime *metav1.Time `json:"lastRegistrationCheckTime,omitempty"`
 }
 

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.3
+version: 0.10.4
 
 home: https://github.com/summerwind/actions-runner-controller
 

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -1543,6 +1543,7 @@ spec:
           properties:
             lastRegistrationCheckTime:
               format: date-time
+              nullable: true
               type: string
             message:
               type: string

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -1543,6 +1543,7 @@ spec:
           properties:
             lastRegistrationCheckTime:
               format: date-time
+              nullable: true
               type: string
             message:
               type: string


### PR DESCRIPTION
Honestly speaking, I'm quite not sure why our integration test is unable to catch this kind of errors. But anyway- here's the fix.

Follow-up for #398 and #404

Ref #400