### PR TITLE
Add metrics of RunnerDeployment and HRA

### DIFF
--- a/controllers/horizontalrunnerautoscaler_controller.go
+++ b/controllers/horizontalrunnerautoscaler_controller.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/summerwind/actions-runner-controller/api/v1alpha1"
+	"github.com/summerwind/actions-runner-controller/controllers/metrics"
 )
 
 const (
@@ -72,6 +73,8 @@ func (r *HorizontalRunnerAutoscalerReconciler) Reconcile(req ctrl.Request) (ctrl
 	if !hra.ObjectMeta.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil
 	}
+
+	metrics.SetHorizontalRunnerAutoscalerSpec(hra.ObjectMeta, hra.Spec)
 
 	var rd v1alpha1.RunnerDeployment
 	if err := r.Get(ctx, types.NamespacedName{
@@ -145,6 +148,8 @@ func (r *HorizontalRunnerAutoscalerReconciler) Reconcile(req ctrl.Request) (ctrl
 	}
 
 	if updated != nil {
+		metrics.SetHorizontalRunnerAutoscalerStatus(updated.ObjectMeta, updated.Status)
+
 		if err := r.Status().Patch(ctx, updated, client.MergeFrom(&hra)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("patching horizontalrunnerautoscaler status to add cache entry: %w", err)
 		}

--- a/controllers/metrics/horizontalrunnerautoscaler.go
+++ b/controllers/metrics/horizontalrunnerautoscaler.go
@@ -22,21 +22,21 @@ var (
 var (
 	horizontalRunnerAutoscalerMinReplicas = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "horizontal_runner_autoscaler_min_replicas",
+			Name: "horizontalrunnerautoscaler_spec_min_replicas",
 			Help: "minReplicas of HorizontalRunnerAutoscaler",
 		},
 		[]string{hraName, hraNamespace},
 	)
 	horizontalRunnerAutoscalerMaxReplicas = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "horizontal_runner_autoscaler_max_replicas",
+			Name: "horizontalrunnerautoscaler_spec_max_replicas",
 			Help: "maxReplicas of HorizontalRunnerAutoscaler",
 		},
 		[]string{hraName, hraNamespace},
 	)
 	horizontalRunnerAutoscalerDesiredReplicas = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "horizontal_runner_autoscaler_desired_replicas",
+			Name: "horizontalrunnerautoscaler_status_desired_replicas",
 			Help: "desiredReplicas of HorizontalRunnerAutoscaler",
 		},
 		[]string{hraName, hraNamespace},

--- a/controllers/metrics/horizontalrunnerautoscaler.go
+++ b/controllers/metrics/horizontalrunnerautoscaler.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	hraName      = "hra_name"
-	hraNamespace = "hra_namespace"
+	hraName      = "horizontalrunnerautoscaler"
+	hraNamespace = "namespace"
 )
 
 var (

--- a/controllers/metrics/horizontalrunnerautoscaler.go
+++ b/controllers/metrics/horizontalrunnerautoscaler.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/summerwind/actions-runner-controller/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	hraName      = "hra_name"
+	hraNamespace = "hra_namespace"
+)
+
+var (
+	horizontalRunnerAutoscalerMetrics = []prometheus.Collector{
+		horizontalRunnerAutoscalerMinReplicas,
+		horizontalRunnerAutoscalerMaxReplicas,
+		horizontalRunnerAutoscalerDesiredReplicas,
+	}
+)
+
+var (
+	horizontalRunnerAutoscalerMinReplicas = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontal_runner_autoscaler_min_replicas",
+			Help: "minReplicas of HorizontalRunnerAutoscaler",
+		},
+		[]string{hraName, hraNamespace},
+	)
+	horizontalRunnerAutoscalerMaxReplicas = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontal_runner_autoscaler_max_replicas",
+			Help: "maxReplicas of HorizontalRunnerAutoscaler",
+		},
+		[]string{hraName, hraNamespace},
+	)
+	horizontalRunnerAutoscalerDesiredReplicas = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontal_runner_autoscaler_desired_replicas",
+			Help: "desiredReplicas of HorizontalRunnerAutoscaler",
+		},
+		[]string{hraName, hraNamespace},
+	)
+)
+
+func SetHorizontalRunnerAutoscalerSpec(o metav1.ObjectMeta, spec v1alpha1.HorizontalRunnerAutoscalerSpec) {
+	labels := prometheus.Labels{
+		hraName:      o.Name,
+		hraNamespace: o.Namespace,
+	}
+	if spec.MaxReplicas != nil {
+		horizontalRunnerAutoscalerMaxReplicas.With(labels).Set(float64(*spec.MaxReplicas))
+	}
+	if spec.MinReplicas != nil {
+		horizontalRunnerAutoscalerMinReplicas.With(labels).Set(float64(*spec.MinReplicas))
+	}
+}
+
+func SetHorizontalRunnerAutoscalerStatus(o metav1.ObjectMeta, status v1alpha1.HorizontalRunnerAutoscalerStatus) {
+	labels := prometheus.Labels{
+		hraName:      o.Name,
+		hraNamespace: o.Namespace,
+	}
+	if status.DesiredReplicas != nil {
+		horizontalRunnerAutoscalerDesiredReplicas.With(labels).Set(float64(*status.DesiredReplicas))
+	}
+}

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -1,0 +1,14 @@
+// Package metrics provides the metrics of custom resources such as HRA.
+//
+// This depends on the metrics exporter of kubebuilder.
+// See https://book.kubebuilder.io/reference/metrics.html for details.
+package metrics
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func init() {
+	metrics.Registry.MustRegister(runnerDeploymentMetrics...)
+	metrics.Registry.MustRegister(horizontalRunnerAutoscalerMetrics...)
+}

--- a/controllers/metrics/runnerdeployment.go
+++ b/controllers/metrics/runnerdeployment.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/summerwind/actions-runner-controller/api/v1alpha1"
+)
+
+const (
+	rdName      = "rd_name"
+	rdNamespace = "rd_namespace"
+)
+
+var (
+	runnerDeploymentMetrics = []prometheus.Collector{
+		runnerDeploymentReplicas,
+	}
+)
+
+var (
+	runnerDeploymentReplicas = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "runner_deployment_replicas",
+			Help: "replicas of RunnerDeployment",
+		},
+		[]string{rdName, rdNamespace},
+	)
+)
+
+func SetRunnerDeployment(rd v1alpha1.RunnerDeployment) {
+	labels := prometheus.Labels{
+		rdName:      rd.Name,
+		rdNamespace: rd.Namespace,
+	}
+	if rd.Spec.Replicas != nil {
+		runnerDeploymentReplicas.With(labels).Set(float64(*rd.Spec.Replicas))
+	}
+}

--- a/controllers/metrics/runnerdeployment.go
+++ b/controllers/metrics/runnerdeployment.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	rdName      = "rd_name"
-	rdNamespace = "rd_namespace"
+	rdName      = "runnerdeployment"
+	rdNamespace = "namespace"
 )
 
 var (

--- a/controllers/metrics/runnerdeployment.go
+++ b/controllers/metrics/runnerdeployment.go
@@ -19,7 +19,7 @@ var (
 var (
 	runnerDeploymentReplicas = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "runner_deployment_replicas",
+			Name: "runnerdeployment_spec_replicas",
 			Help: "replicas of RunnerDeployment",
 		},
 		[]string{rdName, rdNamespace},

--- a/controllers/runnerdeployment_controller.go
+++ b/controllers/runnerdeployment_controller.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/summerwind/actions-runner-controller/api/v1alpha1"
+	"github.com/summerwind/actions-runner-controller/controllers/metrics"
 )
 
 const (
@@ -76,6 +77,8 @@ func (r *RunnerDeploymentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	if !rd.ObjectMeta.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil
 	}
+
+	metrics.SetRunnerDeployment(rd)
 
 	var myRunnerReplicaSetList v1alpha1.RunnerReplicaSetList
 	if err := r.List(ctx, &myRunnerReplicaSetList, client.InNamespace(req.Namespace), client.MatchingFields{runnerSetOwnerKey: req.Name}); err != nil {


### PR DESCRIPTION
I'd like to monitor the metrics of RunnerDeployment and HorizontalRunnerAutoscaler.

This PR includes the following metrics:

- horizontal_runner_autoscaler_min_replicas
- horizontal_runner_autoscaler_max_replicas
- horizontal_runner_autoscaler_desired_replicas
- runner_deployment_replicas

Related to https://github.com/summerwind/actions-runner-controller/pull/312.