### PR TITLE
Fix helm webhook ingress error: `port name or number is required`

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.4
+version: 0.10.5
 
 home: https://github.com/summerwind/actions-runner-controller
 

--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.githubWebhookServer.ingress.enabled -}}
 {{- $fullName := include "actions-runner-controller-github-webhook-server.fullname" . -}}
-{{- $svcPort := .Values.githubWebhookServer.service.port -}}
+{{- $svcPort := (index .Values.githubWebhookServer.service.ports 0).port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}


### PR DESCRIPTION
Use the first exposed port for the service