### PR TITLE
Make acceptance use local docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ release/clean:
 	rm -rf release
 
 .PHONY: acceptance
-acceptance: release/clean docker-build docker-push release
+acceptance: release/clean docker-build release
 	ACCEPTANCE_TEST_SECRET_TYPE=token make acceptance/kind acceptance/setup acceptance/tests acceptance/teardown
 	ACCEPTANCE_TEST_SECRET_TYPE=app make acceptance/kind acceptance/setup acceptance/tests acceptance/teardown
 	ACCEPTANCE_TEST_DEPLOYMENT_TOOL=helm ACCEPTANCE_TEST_SECRET_TYPE=token make acceptance/kind acceptance/setup acceptance/tests acceptance/teardown
@@ -134,6 +134,7 @@ acceptance: release/clean docker-build docker-push release
 
 acceptance/kind:
 	kind create cluster --name acceptance
+	kind load docker-image ${NAME}:${VERSION} --name acceptance
 	kubectl cluster-info --context kind-acceptance
 
 acceptance/setup:

--- a/acceptance/checks.sh
+++ b/acceptance/checks.sh
@@ -12,6 +12,9 @@ done
 
 echo Found runner ${runner_name}.
 
+# Wait a bit to make sure the runner pod is created before looking for it.
+sleep 2
+
 pod_name=
 
 while [ -z "${pod_name}" ]; do
@@ -24,6 +27,6 @@ echo Found pod ${pod_name}.
 
 echo Waiting for pod ${runner_name} to become ready... 1>&2
 
-kubectl wait pod/${runner_name} --for condition=ready --timeout 180s
+kubectl wait pod/${runner_name} --for condition=ready --timeout 270s
 
 echo All tests passed. 1>&2


### PR DESCRIPTION
This Pull Request makes the acceptance build target load the local docker image to the kind cluster.
This is saves both time and bandwidth, and should thus be preferable over pushing it and then pulling it 4 times.
This PR also adds a small delay in acceptance/checks.sh and increases the ready timeout in the same file, because while everything else was working most of the time with the default timeouts, this consistently failed, even with an average download speed of 40 mbit.

I would also like to locally cache the other docker images used by make acceptance on the host, as downloading them 4 times seems like a waste of time and bandwidth.
However this would likely require changing their ImagePullPolicy to IfNotPreset, so i wanted to ask here whether that would have a chance of getting merged.
So would it have a chance?