### PR TITLE
docs: removing superfluous title reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ ToC:
   - [Software installed in the runner image](#software-installed-in-the-runner-image)
   - [Common errors](#common-errors)
 - [Developing](#developing)
-- [Alternatives](#alternatives)
 
 ## Motivation
 


### PR DESCRIPTION
Missed this in https://github.com/summerwind/actions-runner-controller/pull/450