### PR TITLE
feat: Docker registry mirror

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-### Helm Verison Bumps
+### Helm Version Bumps
 
 **Chart Version :** When bumping the chart version follow semantic versioning https://semver.org/<br />
 **App Version :** When bumping the app version you will also need to bump the chart verison too. Again, follow semantic verisoning when bumping the chart.

--- a/README.md
+++ b/README.md
@@ -587,6 +587,8 @@ spec:
       # false (default) = Docker support is provided by a sidecar container deployed in the runner pod.
       # true = No docker sidecar container is deployed in the runner pod but docker can be used within teh runner container instead. The image summerwind/actions-runner-dind is used by default.
       dockerdWithinRunnerContainer: true
+      # Optional Docker registry mirror, only applicable if dockerdWithinRunnerContainer = true
+      dockerRegistryMirror: https://mirror.gcr.io/
       # Docker sidecar container image tweaks examples below, only applicable if dockerdWithinRunnerContainer = false
       dockerdContainerResources:
         limits:

--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"errors"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	corev1 "k8s.io/api/core/v1"
@@ -97,6 +98,8 @@ type RunnerSpec struct {
 	DockerEnabled *bool `json:"dockerEnabled,omitempty"`
 	// +optional
 	DockerMTU *int64 `json:"dockerMTU,omitempty"`
+	// +optional
+	DockerRegistryMirror *string `json:"dockerRegistryMirror,omitempty"`
 	// +optional
 	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -706,6 +706,11 @@ func (in *RunnerSpec) DeepCopyInto(out *RunnerSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.DockerRegistryMirror != nil {
+		in, out := &in.DockerRegistryMirror, &out.DockerRegistryMirror
+		*out = new(string)
+		**out = **in
+	}
 	if in.HostAliases != nil {
 		in, out := &in.HostAliases, &out.HostAliases
 		*out = make([]v1.HostAlias, len(*in))

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -436,6 +436,8 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerRegistryMirror:
+                      type: string
                     dockerVolumeMounts:
                       items:
                         description: VolumeMount describes a mounting of a Volume within a container.

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -436,6 +436,8 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerRegistryMirror:
+                      type: string
                     dockerVolumeMounts:
                       items:
                         description: VolumeMount describes a mounting of a Volume within a container.

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -401,6 +401,8 @@ spec:
             dockerMTU:
               format: int64
               type: integer
+            dockerRegistryMirror:
+              type: string
             dockerVolumeMounts:
               items:
                 description: VolumeMount describes a mounting of a Volume within a container.

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -436,6 +436,8 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerRegistryMirror:
+                      type: string
                     dockerVolumeMounts:
                       items:
                         description: VolumeMount describes a mounting of a Volume within a container.

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -436,6 +436,8 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerRegistryMirror:
+                      type: string
                     dockerVolumeMounts:
                       items:
                         description: VolumeMount describes a mounting of a Volume within a container.

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -401,6 +401,8 @@ spec:
             dockerMTU:
               format: int64
               type: integer
+            dockerRegistryMirror:
+              type: string
             dockerVolumeMounts:
               items:
                 description: VolumeMount describes a mounting of a Volume within a container.

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -635,6 +635,15 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 		}...)
 	}
 
+	if mirror := runner.Spec.DockerRegistryMirror; mirror != nil && dockerdInRunner {
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []corev1.EnvVar{
+			{
+				Name:  "DOCKER_REGISTRY_MIRROR",
+				Value: *runner.Spec.DockerRegistryMirror,
+			},
+		}...)
+	}
+
 	//
 	// /runner must be generated on runtime from /runnertmp embedded in the container image.
 	//
@@ -758,6 +767,11 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 			)
 		}
 
+		if mirror := runner.Spec.DockerRegistryMirror; mirror != nil {
+			pod.Spec.Containers[1].Args = append(pod.Spec.Containers[1].Args,
+				fmt.Sprintf("--registry-mirror=%s", *runner.Spec.DockerRegistryMirror),
+			)
+		}
 	}
 
 	if len(runner.Spec.Containers) != 0 {

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -20,21 +20,17 @@ function wait_for_process () {
 sudo /bin/bash <<SCRIPT
 mkdir -p /etc/docker
 
-cat <<EOS > /etc/docker/daemon.json
-{
-EOS
+echo "{}" > /etc/docker/daemon.json
 
 if [ -n "${MTU}" ]; then
-cat <<EOS >> /etc/docker/daemon.json
-  "mtu": ${MTU}
-EOS
+jq ".\"mtu\" = ${MTU}" /etc/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /etc/docker/daemon.json
 # See https://docs.docker.com/engine/security/rootless/
 echo "environment=DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=${MTU}" >> /etc/supervisor/conf.d/dockerd.conf
 fi
 
-cat <<EOS >> /etc/docker/daemon.json
-}
-EOS
+if [ -n "${DOCKER_REGISTRY_MIRROR}" ]; then
+jq ".\"registry-mirrors\"[0] = \"${DOCKER_REGISTRY_MIRROR}\"" /etc/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /etc/docker/daemon.json
+fi
 SCRIPT
 
 INFO "Using /etc/docker/daemon.json with the following content"


### PR DESCRIPTION
- Switched to use `jq` in startup.sh
- Should enable docker registry mirror configuration if `dockerdWithinRunnerContainer` has been set, that's needed due to the current Docker Hub rate-limiting

### DinD: Mirror only
```
apiVersion: actions.summerwind.dev/v1alpha1
kind: RunnerDeployment
spec:
  template:
    spec:
      dockerdWithinRunnerContainer: true
      dockerMTU: 1500
      dockerRegistryMirror: https://mirror.xxx.xxx
```
```
[Sat Apr 24 12:40:03 UTC 2021] [INFO] [/usr/local/bin/startup.sh] Using /etc/docker/daemon.json with the following content
{
  "registry-mirrors": [
    "https://mirror.xxx.xxx"
  ]
}
[Sat Apr 24 12:40:03 UTC 2021] [INFO] [/usr/local/bin/startup.sh] Using /etc/supervisor/conf.d/dockerd.conf with the following content
[program:dockerd]
command=/usr/local/bin/dockerd
autostart=true
autorestart=true
stderr_logfile=/var/log/dockerd.err.log
stdout_logfile=/var/log/dockerd.out.log
[Sat Apr 24 12:40:03 UTC 2021] [INFO] [/usr/local/bin/startup.sh] Starting supervisor
```

### DinD: Mirror + MTU
```
apiVersion: actions.summerwind.dev/v1alpha1
kind: RunnerDeployment
spec:
  template:
    spec:
      dockerdWithinRunnerContainer: true
      dockerMTU: 1500
      dockerRegistryMirror: https://mirror.xxx.xxx
```
```
[Sat Apr 24 12:46:40 UTC 2021] [INFO] [/usr/local/bin/startup.sh] Using /etc/docker/daemon.json with the following content
{
  "mtu": 1500,
  "registry-mirrors": [
    "https://mirror.xxx.xxx"
  ]
}
[Sat Apr 24 12:46:40 UTC 2021] [INFO] [/usr/local/bin/startup.sh] Using /etc/supervisor/conf.d/dockerd.conf with the following content
[program:dockerd]
command=/usr/local/bin/dockerd
autostart=true
autorestart=true
stderr_logfile=/var/log/dockerd.err.log
stdout_logfile=/var/log/dockerd.out.log
environment=DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=1500
[Sat Apr 24 12:46:40 UTC 2021] [INFO] [/usr/local/bin/startup.sh] Starting supervisor
```

### Mirror + MTU
```
      dockerdWithinRunnerContainer: false
      dockerMTU: 1500
      dockerRegistryMirror: https://mirror.xxx.xxx
```
```
$ kubectl exec -it ghe-runner-deployment-r8hhs-lx2ck -c docker -- cat /proc/1/cmdline
dockerd--host=unix:///var/run/docker.sock--host=tcp://0.0.0.0:2376--tlsverify--tlscacert/certs/server/ca.pem--tlscert/certs/server/cert.pem--tlskey/certs/server/key.pem--mtu1500--registry-mirror=https://mirror.xxx.xxx%
```