### PR TITLE
docs: updating helm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ kubectl apply -f https://github.com/summerwind/actions-runner-controller/release
 
 ```shell
 helm repo add actions-runner-controller https://summerwind.github.io/actions-runner-controller
-helm upgrade --install -n actions-runner-system actions-runner-controller/actions-runner-controller
+helm upgrade --install --namespace actions-runner-system --create-namespace \ 
+             --wait actions-runner-controller actions-runner-controller/actions-runner-controller
 ```
 
 ### GitHub Enterprise Support


### PR DESCRIPTION
Fixes https://github.com/summerwind/actions-runner-controller/issues/483 somewhat

To be honest the install instructions probably need re-ordering and rewriting a bit. The structure of the install steps were created pre-helm chart and GitHub Enterprise Server support and so it doesn't really work as well as it did originally.

The install process should probably be split into 2 sections:

- Kustomize
- Helm